### PR TITLE
Data tables save table state

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12289,10 +12289,10 @@ const applyDatatables = () => {
                 // Remember page/search/order
                 stateSave: true,
                 stateSaveCallback: function(settings, data) {
-                    localStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                    sessionStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
                 },
                 stateLoadCallback: function(settings) {
-                    return JSON.parse(localStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
+                    return JSON.parse(sessionStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
                 },
                 // Bootstrap style tables, with responsive table
                 dom: `<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>><'row table-responsive'<'col-sm-12'tr>><'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7 text-center'p>>`,

--- a/bundle.js
+++ b/bundle.js
@@ -12286,6 +12286,14 @@ const applyDatatables = () => {
             if (rows < 40 || doNotProcess) return;
 
             $(element).DataTable({
+                // Remember page/search/order
+                stateSave: true,
+                stateSaveCallback: function(settings, data) {
+                    localStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                },
+                stateLoadCallback: function(settings) {
+                    return JSON.parse(localStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
+                },
                 // Bootstrap style tables, with responsive table
                 dom: `<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>><'row table-responsive'<'col-sm-12'tr>><'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7 text-center'p>>`,
                 // Our custom page implementation 

--- a/bundle.js
+++ b/bundle.js
@@ -12290,6 +12290,12 @@ const applyDatatables = () => {
                 stateSave: true,
                 stateSaveCallback: function(settings, data) {
                     sessionStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                    // Only keep tables position if on same page type/parent
+                    Object.keys(sessionStorage).forEach((key) => {
+                        if (key.startsWith('DataTables') && !key.includes(Wiki.pageType())) {
+                            delete sessionStorage[key];
+                        }
+                    })
                 },
                 stateLoadCallback: function(settings) {
                     return JSON.parse(sessionStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');

--- a/scripts/datatables.js
+++ b/scripts/datatables.js
@@ -14,10 +14,10 @@ const applyDatatables = () => {
                 // Remember page/search/order
                 stateSave: true,
                 stateSaveCallback: function(settings, data) {
-                    localStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                    sessionStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
                 },
                 stateLoadCallback: function(settings) {
-                    return JSON.parse(localStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
+                    return JSON.parse(sessionStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
                 },
                 // Bootstrap style tables, with responsive table
                 dom: `<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>><'row table-responsive'<'col-sm-12'tr>><'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7 text-center'p>>`,

--- a/scripts/datatables.js
+++ b/scripts/datatables.js
@@ -11,6 +11,14 @@ const applyDatatables = () => {
             if (rows < 40 || doNotProcess) return;
 
             $(element).DataTable({
+                // Remember page/search/order
+                stateSave: true,
+                stateSaveCallback: function(settings, data) {
+                    localStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                },
+                stateLoadCallback: function(settings) {
+                    return JSON.parse(localStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');
+                },
                 // Bootstrap style tables, with responsive table
                 dom: `<'row'<'col-sm-12 col-md-6'l><'col-sm-12 col-md-6'f>><'row table-responsive'<'col-sm-12'tr>><'row'<'col-sm-12 col-md-5'i><'col-sm-12 col-md-7 text-center'p>>`,
                 // Our custom page implementation 

--- a/scripts/datatables.js
+++ b/scripts/datatables.js
@@ -15,6 +15,12 @@ const applyDatatables = () => {
                 stateSave: true,
                 stateSaveCallback: function(settings, data) {
                     sessionStorage.setItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`, JSON.stringify(data));
+                    // Only keep tables position if on same page type/parent
+                    Object.keys(sessionStorage).forEach((key) => {
+                        if (key.startsWith('DataTables') && !key.includes(Wiki.pageType())) {
+                            delete sessionStorage[key];
+                        }
+                    })
                 },
                 stateLoadCallback: function(settings) {
                     return JSON.parse(sessionStorage.getItem(`DataTables_${Wiki.pageType()}_${Wiki.pageName()}_${i}`) || '{}');


### PR DESCRIPTION
Save table state as long as you are still under the same parent category

Example: `Pokemon` or `Pokemon/Pikachu` will keep the table state, but if you went to homepage or `Berries`, the next time you went to the `Pokemon` page, the table would start from it's original state.