### PR TITLE
[FIX] Don't floor the attack bonus

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12866,7 +12866,7 @@ module.exports = {
 const getBreedingAttackBonus = (vitaminsUsed, baseAttack) => {
     const attackBonusPercent = (GameConstants.BREEDING_ATTACK_BONUS + vitaminsUsed[GameConstants.VitaminType.Calcium]) / 100;
     const proteinBoost = vitaminsUsed[GameConstants.VitaminType.Protein];
-    return Math.floor((baseAttack * attackBonusPercent) + proteinBoost);
+    return (baseAttack * attackBonusPercent) + proteinBoost;
 }
 
 const calcEggSteps = (vitaminsUsed, eggCycles) => {
@@ -12920,6 +12920,7 @@ module.exports = {
     getEfficiency,
     getBestVitamins,
 }
+
 },{}],115:[function(require,module,exports){
 const { gotoPage } = require('./navigation');
 

--- a/scripts/pages/pokemon.js
+++ b/scripts/pages/pokemon.js
@@ -2,7 +2,7 @@
 const getBreedingAttackBonus = (vitaminsUsed, baseAttack) => {
     const attackBonusPercent = (GameConstants.BREEDING_ATTACK_BONUS + vitaminsUsed[GameConstants.VitaminType.Calcium]) / 100;
     const proteinBoost = vitaminsUsed[GameConstants.VitaminType.Protein];
-    return Math.floor((baseAttack * attackBonusPercent) + proteinBoost);
+    return (baseAttack * attackBonusPercent) + proteinBoost;
 }
 
 const calcEggSteps = (vitaminsUsed, eggCycles) => {


### PR DESCRIPTION
The Pokémon's attack bonus was rounded down, resulting in incorrect numbers and weird behavior.
Screenshots are from the page of Heracross.

Before:
![image](https://user-images.githubusercontent.com/21047644/216854575-d104e5d7-efe6-4665-824e-4309ea9f5fd5.png)

After:
![image](https://user-images.githubusercontent.com/21047644/216854595-54dcba3d-f971-4c25-b620-da541cecb5dc.png)
