### PR TITLE
[FIX] Mega Pokémon: Link to Coumarine City

### DIFF
--- a/pages/Mega Pokémon/overview.html
+++ b/pages/Mega Pokémon/overview.html
@@ -42,7 +42,7 @@ const megaInfo = {
     },
     'Mega Ampharos': {
         megaStone: 'Ampharosite',
-        method: `Enter the code given by the Electric Trainer in [[Towns/Courmarine City]] (including the question mark) in the Start -> Save menu.`,
+        method: `Enter the code given by the Electric Trainer in [[Towns/Coumarine City]] (including the question mark) in the Start -> Save menu.`,
     },
     'Mega Heracross': {
         megaStone: 'Heracronite',


### PR DESCRIPTION
The page was incorrectly linking to Courmarine City, which does not exist.