### PR TITLE
Allow matching e and é

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -13204,7 +13204,7 @@ searchOptions.forEach(a => {
 */
 
 function escapeRegExp(text) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&').replace(/[eé]/g, '[eé]');
 }
 // This is the function which figures out the results to show
 var substringMatcher = (searchData) => {

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -186,7 +186,7 @@ searchOptions.forEach(a => {
 */
 
 function escapeRegExp(text) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&').replace(/[eé]/g, '[eé]');
 }
 // This is the function which figures out the results to show
 var substringMatcher = (searchData) => {


### PR DESCRIPTION
Unfortunately, the highlighting does not support this. I have looked into that and it seems that it's not possible with the version of typeahead we use, see the non-minified version:
https://cdnjs.cloudflare.com/ajax/libs/typeahead.js/0.11.1/typeahead.bundle.js, line 1377

A more general solution including other diacritics would be better, but I want to get this done since é is commonly used in Pokémon. Who would've guessed?