### PR TITLE
Adds Category Column to Items Page

### DIFF
--- a/pages/Items/overview.html
+++ b/pages/Items/overview.html
@@ -3,6 +3,7 @@
         <thead class="thead-dark">
             <tr>
                 <th>Item Name</th>
+                <th>Category</th>
                 <th>Description</th>
             </tr>
         </thead>
@@ -10,12 +11,14 @@
             <!-- ko foreach: Object.values(ItemList) -->
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Items', $data.displayName); return false; }">
                 <td data-bind="text: $data.displayName"></td>
-                <td data-bind="html: $data.description"></td>
+                <td data-bind="html: GameConstants.camelCaseToString($data.constructor.name)"></td>
+                <td data-bind="html: $data.description"></td>          
             </tr>
             <!-- /ko -->
             <!-- ko foreach: UndergroundItems.list.filter((ui) => !Object.values(ItemList).some((i) => i.displayName == ui.displayName)) -->
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Items', $data.displayName); return false; }">
                 <td data-bind="text: $data.displayName"></td>
+                <td data-bind="html: GameConstants.camelCaseToString($data.constructor.name)"></td>
                 <td>An item found in the underground</td>
             </tr>
             <!-- /ko -->


### PR DESCRIPTION
Added an extra column to the Items page that displays the category of said item. This way people can more easily search for certain items, like typing "Pokemon" will show you all the shop mons, to give an example.