### PR TITLE
Farm Simulator - Growth time updates

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -13296,34 +13296,46 @@ const getFlavorValue = (flavorType) => {
     return App.game.farming.berryData[selectedPlot().berry].flavors.find(f => f.type === flavorType).value;
 }
 
-const getStageTimes = ko.pureComputed(() => {
-    const stages = [
-        { stage: 'Sprout', timeLeft: '-' },
-        { stage: 'Taller', timeLeft: '-' },
-        { stage: 'Bloom', timeLeft: '-' },
-        { stage: 'Berry', timeLeft: '-' },
-        { stage: 'Wither', timeLeft: '-' },
-    ];
-
-    if (!selectedPlot() || selectedPlot()._berry() == -1) {
-        return stages;
-    }
-
-    const isPetaya = selectedPlot().berry === BerryType.Petaya;
-    const petayaEffect = App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && !isPetaya;
-
-    stages.forEach((stage, idx) => {
-        const growthTime = App.game.farming.berryData[selectedPlot().berry].growthTime[idx];
-        const growthMultiplier = App.game.farming.getGrowthMultiplier() * selectedPlot().getGrowthMultiplier();
-        if (growthMultiplier == 0 || (petayaEffect && stage.stage == 'Wither')) {
-            stages[idx].timeLeft = '∞';
-        } else {
-            stages[idx].timeLeft = GameConstants.formatTimeFullLetters(growthTime / growthMultiplier);
+const getStageTimes = (calcTotalLifeTime = false) => {
+    return ko.pureComputed(() => {
+        const stages = [
+            { stage: 'Sprout', timeLeft: '-' },
+            { stage: 'Taller', timeLeft: '-' },
+            { stage: 'Bloom', timeLeft: '-' },
+            { stage: 'Berry', timeLeft: '-' },
+            { stage: 'Wither', timeLeft: '-' },
+        ];
+    
+        if (!selectedPlot() || selectedPlot()._berry() == -1) {
+            return stages;
         }
-    });
+    
+        const isPetaya = selectedPlot().berry === BerryType.Petaya;
+        const petayaEffect = App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && !isPetaya;
+        const dummyPlot = new Plot(true, selectedPlot().berry, 0, selectedPlot().mulch, selectedPlot().mulchTimeLeft, selectedPlot().index);
+        let totalLifeTime = 0;
 
-    return stages;
-});
+        stages.forEach((stage, idx) => {
+            const prevStageTime = idx == 0 ? 0 : App.game.farming.berryData[selectedPlot().berry].growthTime[idx - 1];
+            const growthTime = App.game.farming.berryData[selectedPlot().berry].growthTime[idx] - prevStageTime;
+            dummyPlot._age(growthTime);
+            const growthMultiplier = App.game.farming.getGrowthMultiplier() * dummyPlot.getGrowthMultiplier();
+
+            if (growthMultiplier == 0 || (petayaEffect && stage.stage == 'Wither')) {
+                stages[idx].timeLeft = '∞';
+            } else {
+                const timeLeft = growthTime / growthMultiplier;
+                stages[idx].timeLeft = GameConstants.formatTimeFullLetters(timeLeft + totalLifeTime);
+
+                if (calcTotalLifeTime) {
+                    totalLifeTime += timeLeft;
+                }
+            }
+        });
+
+        return stages;
+    });
+}
 
 const getEmittingAura = ko.pureComputed(() => {
     if (!selectedPlot() || selectedPlot()._berry() == -1 || selectedPlot().emittingAura.type() == null) {

--- a/pages/Farm Simulator/overview.html
+++ b/pages/Farm Simulator/overview.html
@@ -147,13 +147,32 @@
                     </div>
                 </div>
                 <hr />
-                <div class="d-flex flex-row justify-content-around text-center">
-                    <!-- ko foreach: Wiki.farmSimulator.getStageTimes() -->
-                    <div>
-                        <div class="mb-2" data-bind="text: $data.stage"></div>
-                        <div class="small" data-bind="text: $data.timeLeft"></div>
-                    </div>
-                    <!-- /ko -->
+                <div class="table-response">
+                    <table class="table table-sm table-hover text-center">
+                        <thead>
+                            <tr>
+                                <th>Sprout</th>
+                                <th>Taller</th>
+                                <th>Bloom</th>
+                                <th>Berry</th>
+                                <th>Wither</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr><td class="small text-muted" colspan="5">Time From Previous Stage</td></tr>
+                            <tr>
+                                <!-- ko foreach: Wiki.farmSimulator.getStageTimes(false) -->
+                                <td class="small" data-bind="text: $data.timeLeft"></td>
+                                <!-- /ko -->
+                            </tr>
+                            <tr><td class="small text-muted" colspan="5">Time Since Planted</td></tr>
+                            <tr>
+                                <!-- ko foreach: Wiki.farmSimulator.getStageTimes(true) -->
+                                <td class="small border-bottom-0" data-bind="text: $data.timeLeft"></td>
+                                <!-- /ko -->
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
                 <hr />
                 <div class="d-flex flex-row justify-content-around text-center">

--- a/scripts/pages/farmSimulator.js
+++ b/scripts/pages/farmSimulator.js
@@ -143,34 +143,46 @@ const getFlavorValue = (flavorType) => {
     return App.game.farming.berryData[selectedPlot().berry].flavors.find(f => f.type === flavorType).value;
 }
 
-const getStageTimes = ko.pureComputed(() => {
-    const stages = [
-        { stage: 'Sprout', timeLeft: '-' },
-        { stage: 'Taller', timeLeft: '-' },
-        { stage: 'Bloom', timeLeft: '-' },
-        { stage: 'Berry', timeLeft: '-' },
-        { stage: 'Wither', timeLeft: '-' },
-    ];
-
-    if (!selectedPlot() || selectedPlot()._berry() == -1) {
-        return stages;
-    }
-
-    const isPetaya = selectedPlot().berry === BerryType.Petaya;
-    const petayaEffect = App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && !isPetaya;
-
-    stages.forEach((stage, idx) => {
-        const growthTime = App.game.farming.berryData[selectedPlot().berry].growthTime[idx];
-        const growthMultiplier = App.game.farming.getGrowthMultiplier() * selectedPlot().getGrowthMultiplier();
-        if (growthMultiplier == 0 || (petayaEffect && stage.stage == 'Wither')) {
-            stages[idx].timeLeft = '∞';
-        } else {
-            stages[idx].timeLeft = GameConstants.formatTimeFullLetters(growthTime / growthMultiplier);
+const getStageTimes = (calcTotalLifeTime = false) => {
+    return ko.pureComputed(() => {
+        const stages = [
+            { stage: 'Sprout', timeLeft: '-' },
+            { stage: 'Taller', timeLeft: '-' },
+            { stage: 'Bloom', timeLeft: '-' },
+            { stage: 'Berry', timeLeft: '-' },
+            { stage: 'Wither', timeLeft: '-' },
+        ];
+    
+        if (!selectedPlot() || selectedPlot()._berry() == -1) {
+            return stages;
         }
-    });
+    
+        const isPetaya = selectedPlot().berry === BerryType.Petaya;
+        const petayaEffect = App.game.farming.berryInFarm(BerryType.Petaya, PlotStage.Berry, true) && !isPetaya;
+        const dummyPlot = new Plot(true, selectedPlot().berry, 0, selectedPlot().mulch, selectedPlot().mulchTimeLeft, selectedPlot().index);
+        let totalLifeTime = 0;
 
-    return stages;
-});
+        stages.forEach((stage, idx) => {
+            const prevStageTime = idx == 0 ? 0 : App.game.farming.berryData[selectedPlot().berry].growthTime[idx - 1];
+            const growthTime = App.game.farming.berryData[selectedPlot().berry].growthTime[idx] - prevStageTime;
+            dummyPlot._age(growthTime);
+            const growthMultiplier = App.game.farming.getGrowthMultiplier() * dummyPlot.getGrowthMultiplier();
+
+            if (growthMultiplier == 0 || (petayaEffect && stage.stage == 'Wither')) {
+                stages[idx].timeLeft = '∞';
+            } else {
+                const timeLeft = growthTime / growthMultiplier;
+                stages[idx].timeLeft = GameConstants.formatTimeFullLetters(timeLeft + totalLifeTime);
+
+                if (calcTotalLifeTime) {
+                    totalLifeTime += timeLeft;
+                }
+            }
+        });
+
+        return stages;
+    });
+}
 
 const getEmittingAura = ko.pureComputed(() => {
     if (!selectedPlot() || selectedPlot()._berry() == -1 || selectedPlot().emittingAura.type() == null) {


### PR DESCRIPTION
Realized that the growth time wasn't being calculated correctly in some cases. Any auras that affected growth time were being applied at the stage of the selected berry rather than the stage they were listed under.

Also split the growth time into two sections: one to display the growth time per stage and one that displays the total growth time since being planted.