### PR TITLE
Dungeon loot v2

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12927,6 +12927,10 @@ module.exports = {
 
 },{}],115:[function(require,module,exports){
 const getTableClearCounts = (dungeon) => {
+    if (getTableClearCounts.cache.has(dungeon)) {
+        return getTableClearCounts.cache.get(dungeon);
+    }
+
     const hasItemsThatIgnoreDebuff = Object.values(dungeon.lootTable).flat().some(item => item.ignoreDebuff);
 
     const tableClearCounts = [
@@ -12962,8 +12966,11 @@ const getTableClearCounts = (dungeon) => {
         });
     }
 
+    getTableClearCounts.cache.set(dungeon, tableClearCounts);
+
     return tableClearCounts;
 };
+getTableClearCounts.cache = new WeakMap();
 
 const itemTypeCategories = {
     pokemon: 'Pokémon',

--- a/bundle.js
+++ b/bundle.js
@@ -12926,32 +12926,44 @@ module.exports = {
 };
 
 },{}],115:[function(require,module,exports){
-const tableClearCounts = [
-    {
-        clears: 0,
-        debuff: false
-    },
-    {
-        clears: 100,
-        debuff: false
-    },
-    {
-        clears: 500,
-        debuff: false
-    },
-    {
-        clears: 0,
-        debuff: true
-    },
-    {
-        clears: 100,
-        debuff: true
-    },
-    {
-        clears: 500,
-        debuff: true
+const getTableClearCounts = (dungeon) => {
+    const hasItemsThatIgnoreDebuff = Object.values(dungeon.lootTable).flat().some(item => item.ignoreDebuff);
+
+    const tableClearCounts = [
+        {
+            clears: 0,
+            debuff: false,
+            header: '0 clears'
+        },
+        {
+            clears: 100,
+            debuff: false,
+            header: '100 clears'
+        },
+        {
+            clears: 250,
+            debuff: false,
+            header: '250 clears'
+        },
+        {
+            clears: 500,
+            debuff: false,
+            header: '500 clears'
+        }
+    ];
+
+    if (hasItemsThatIgnoreDebuff) {
+        tableClearCounts.push(...tableClearCounts.map(clearSetup => ({...clearSetup, debuff: true, header: `Debuffed (${clearSetup.header})`})))
+    } else {
+        tableClearCounts.push({
+            clears: 0,
+            debuff: true,
+            header: 'Debuffed'
+        });
     }
-];
+
+    return tableClearCounts;
+};
 
 const itemTypeCategories = {
     pokemon: 'Pokémon',
@@ -13094,6 +13106,7 @@ const getLootTierWeights = (dungeon, clears, debuffed, requirement = () => true)
 };
 
 const getDungeonLoot = (dungeon) => {
+    const tableClearCounts = getTableClearCounts(dungeon)
     const tierWeights = tableClearCounts.map(clearSetup => getLootTierWeights(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const itemChanceMaps = tableClearCounts.map(clearSetup => getDungeonLootChances(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const lootTiers = [];
@@ -13162,7 +13175,7 @@ module.exports = {
     getDungeonLoot,
     getDungeonLootChances,
     hasLootWithRequirements,
-    tableClearCounts,
+    getTableClearCounts,
     itemTypeCategories
 };
 

--- a/bundle.js
+++ b/bundle.js
@@ -12968,7 +12968,7 @@ const itemTypeCategories = {
  * @return {Map<Loot, number>}
  */
 const getDungeonLootChancesIgnoringFlag = (dungeon, clears, debuffed = false, requirement = () => true) => {
-    const tierWeights = dungeon.getLootTierWeights(clears, debuffed);
+    const tierWeights = getLootTierWeights(dungeon, clears, debuffed, requirement);
     const weightSum = Object.keys(tierWeights)
         .filter(tier => dungeon.lootTable[tier].some(requirement))
         .map(tier => tierWeights[tier])
@@ -13058,11 +13058,46 @@ const checkLootRequirements = (dungeon, clearSetup) => {
     };
 }
 
+/**
+ * Returns the loot tier weights for a given dungeon, clear setup and requirement check.
+ * @param dungeon
+ * @param clears
+ * @param debuffed
+ * @param requirement
+ * @return {Record<string, number>} object mapping loot tiers to weights
+ */
+const getLootTierWeights = (dungeon, clears, debuffed, requirement = () => true) => {
+    const lootToRequirementMap = new Map();
+
+    // Replace requirements with ours
+    for (let tier of Object.keys(dungeon.lootTable)) {
+        for (let item of Object.values(dungeon.lootTable[tier])) {
+            const originalRequirement = item.requirement;
+            lootToRequirementMap.set(item, originalRequirement);
+            item.requirement = {
+                // Pass item with original requirement
+                isCompleted: () => requirement({...item, requirement: originalRequirement})
+            };
+        }
+    }
+
+    const tierWeights = dungeon.getLootTierWeights(clears, debuffed);
+
+    // Restore requirements
+    for (let tier of Object.keys(dungeon.lootTable)) {
+        for (let item of Object.values(dungeon.lootTable[tier])) {
+            item.requirement = lootToRequirementMap.get(item);
+        }
+    }
+
+    return tierWeights;
+};
+
 const getDungeonLoot = (dungeon) => {
-    const tierWeights = tableClearCounts.map(clearSetup => dungeon.getLootTierWeights(clearSetup.clears, clearSetup.debuff));
+    const tierWeights = tableClearCounts.map(clearSetup => getLootTierWeights(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const itemChanceMaps = tableClearCounts.map(clearSetup => getDungeonLootChances(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const lootTiers = [];
-    for (let tier of Object.keys(tierWeights[0]).sort((a, b) => a - b)) {
+    for (let tier of Object.keys(dungeon.lootTable).sort((a, b) => a - b)) {
         const tierLoot = dungeon.lootTable[tier];
         const tierData = {
             tier: GameConstants.camelCaseToString(tier),

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
         <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 
-        <link href="./styles.css?t=1680068802222" rel="stylesheet">
+        <link href="./styles.css?t=1681078929948" rel="stylesheet">
 
     </head>
     <body class="no-select">
@@ -242,6 +242,6 @@
         </template>
 
         <!-- Main wiki script -->
-        <script src="bundle.js?t=1680068802222"></script>
+        <script src="bundle.js?t=1681078929948"></script>
     </body>
 </html>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -67,15 +67,15 @@
                     <tr>
                         <th>Item</th>
                         <th>Weight</th>
-                        <th style="text-align: center" data-bind="attr: { colspan: Wiki.dungeons.tableClearCounts.length }">Chance</th>
+                        <th style="text-align: center" data-bind="attr: { colspan: Wiki.dungeons.getTableClearCounts($data).length }">Chance</th>
                         <!-- ko if: Wiki.dungeons.hasLootWithRequirements($data) -->
                         <th>Requirement</th>
                         <!-- /ko -->
                     </tr>
                     <tr>
                         <th colspan="2"></th>
-                        <!-- ko foreach: Wiki.dungeons.tableClearCounts -->
-                            <th data-bind="text: $data.debuff ? ('Debuffed' + (Wiki.dungeons.tableClearCounts.filter(cc => cc.debuff).length > 1 ? ` (${$data.clears} clear${$data.clears !== 1 ? 's' : ''})` : '')) : `${$data.clears} clear${$data.clears !== 1 ? 's' : ''}`"></th>
+                        <!-- ko foreach: Wiki.dungeons.getTableClearCounts($data) -->
+                            <th data-bind="text: $data.header"></th>
                         <!-- /ko -->
                         <!-- ko if: Wiki.dungeons.hasLootWithRequirements($data) -->
                         <th></th>
@@ -85,7 +85,7 @@
                 <tbody>
                     <!-- ko foreach: Wiki.dungeons.getDungeonLoot($data) -->
                         <tr>
-                            <td style="font-weight: bold; text-transform: capitalize; text-align: center" data-bind="text: $data.tier, attr: { colspan: Wiki.dungeons.tableClearCounts.length + 2 + (Wiki.dungeons.hasLootWithRequirements($parent) ? 1 : 0) }"></td>
+                            <td style="font-weight: bold; text-transform: capitalize; text-align: center" data-bind="text: $data.tier, attr: { colspan: Wiki.dungeons.getTableClearCounts($parent).length + 2 + (Wiki.dungeons.hasLootWithRequirements($parent) ? 1 : 0) }"></td>
                         </tr>
                         <!-- ko foreach: $data.items -->
                             <tr>

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -1,29 +1,41 @@
-const tableClearCounts = [
-    {
-        clears: 0,
-        debuff: false
-    },
-    {
-        clears: 100,
-        debuff: false
-    },
-    {
-        clears: 500,
-        debuff: false
-    },
-    {
-        clears: 0,
-        debuff: true
-    },
-    {
-        clears: 100,
-        debuff: true
-    },
-    {
-        clears: 500,
-        debuff: true
+const getTableClearCounts = (dungeon) => {
+    const hasItemsThatIgnoreDebuff = Object.values(dungeon.lootTable).flat().some(item => item.ignoreDebuff);
+
+    const tableClearCounts = [
+        {
+            clears: 0,
+            debuff: false,
+            header: '0 clears'
+        },
+        {
+            clears: 100,
+            debuff: false,
+            header: '100 clears'
+        },
+        {
+            clears: 250,
+            debuff: false,
+            header: '250 clears'
+        },
+        {
+            clears: 500,
+            debuff: false,
+            header: '500 clears'
+        }
+    ];
+
+    if (hasItemsThatIgnoreDebuff) {
+        tableClearCounts.push(...tableClearCounts.map(clearSetup => ({...clearSetup, debuff: true, header: `Debuffed (${clearSetup.header})`})))
+    } else {
+        tableClearCounts.push({
+            clears: 0,
+            debuff: true,
+            header: 'Debuffed'
+        });
     }
-];
+
+    return tableClearCounts;
+};
 
 const itemTypeCategories = {
     pokemon: 'Pokémon',
@@ -166,6 +178,7 @@ const getLootTierWeights = (dungeon, clears, debuffed, requirement = () => true)
 };
 
 const getDungeonLoot = (dungeon) => {
+    const tableClearCounts = getTableClearCounts(dungeon)
     const tierWeights = tableClearCounts.map(clearSetup => getLootTierWeights(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const itemChanceMaps = tableClearCounts.map(clearSetup => getDungeonLootChances(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const lootTiers = [];
@@ -234,6 +247,6 @@ module.exports = {
     getDungeonLoot,
     getDungeonLootChances,
     hasLootWithRequirements,
-    tableClearCounts,
+    getTableClearCounts,
     itemTypeCategories
 };

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -1,4 +1,8 @@
 const getTableClearCounts = (dungeon) => {
+    if (getTableClearCounts.cache.has(dungeon)) {
+        return getTableClearCounts.cache.get(dungeon);
+    }
+
     const hasItemsThatIgnoreDebuff = Object.values(dungeon.lootTable).flat().some(item => item.ignoreDebuff);
 
     const tableClearCounts = [
@@ -34,8 +38,11 @@ const getTableClearCounts = (dungeon) => {
         });
     }
 
+    getTableClearCounts.cache.set(dungeon, tableClearCounts);
+
     return tableClearCounts;
 };
+getTableClearCounts.cache = new WeakMap();
 
 const itemTypeCategories = {
     pokemon: 'Pokémon',


### PR DESCRIPTION
Fixed an issue with missing tiers when all items in the tier have requirements (Example: Lum in Berry Forest).
Improved table columns - now only shows 1 debuffed column unless the dungeon has items that ignore the debuff.
Added column(s) for 250 clears.

Regular dungeon (with requirements):
![Regular dungeon](https://media.discordapp.net/attachments/738337513168699442/1094699214430273607/image.png)
Dungeon with items that ignore the debuff:
![Dungeon with ignoreDebuff](https://media.discordapp.net/attachments/738337513168699442/1094699214686146660/image.png)