### PR TITLE
Fix berry descriptions

### DIFF
--- a/pages/Berries/main.html
+++ b/pages/Berries/main.html
@@ -63,7 +63,7 @@
             </table>
         </div>
         <h3>Description</h3>
-        <p data-bind="text: $data.description"></p>
+        <p data-bind="text: $data.description.join(' ')"></p>
         <h3>Growth Stages</h3>
         <div class="table-responsive">
             <table class="table table-hover table-striped table-bordered">


### PR DESCRIPTION
Fixes the berry description formatting due to it being an array.

Before:
![image](https://user-images.githubusercontent.com/672420/232642019-1f34ccd1-ab83-4737-aba7-e53069d4b3c9.png)

After:
![image](https://user-images.githubusercontent.com/672420/232642059-e74588f0-0e8a-463a-a7f3-e4cfbeab3af2.png)
