### PR TITLE
Shard Trader / Fossil Master fixes

### DIFF
--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -86,9 +86,9 @@
     </div>
     <!-- Shard Trade -->
     <div class="mt-3" data-bind="if: Object.values(ShardDeal.list).flatMap((d) => d()).find((d) => d.item.itemType.name == $data.name)">
-        <h3>Can be traded for Shards in the following towns:</h3>
-        <div data-bind="foreach: Object.keys(ShardDeal.list).filter((key) => ShardDeal.list[key]().some((d) => d.item.itemType.name == $data.name))">
-            <a class="badge text-bg-secondary" href="#!" data-bind="text: GameConstants.ShardTraderLocations[$data], attr: { href: `#!Towns/${GameConstants.ShardTraderLocations[$data]}` }"></a>
+        <h3>Can be traded for in the following towns:</h3>
+        <div data-bind="foreach: Object.values(TownList).filter(t => t.content.some(c => c instanceof ShardTraderShop && ShardDeal.list[c.location]().some(d => d.item.itemType.name == $data.name)))">
+            <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Towns/${$data.name}` }"></a>
         </div>
     </div>
     <div class="mt-3" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name)))">

--- a/pages/Towns/main.html
+++ b/pages/Towns/main.html
@@ -71,16 +71,16 @@
         </div>
     </div>
     <!-- /ko -->
-    <!-- ko if: $data.content.some((c) => c instanceof ShardTraderShop) -->
+    <!-- ko foreach: $data.content.filter(c => c instanceof ShardTraderShop)  -->
     <div class="mt-3">
-        <h3>Shard Trader</h3>
+        <h3 data-bind="text: $data.name"></h3>
         <div class="table-responsive">
             <table class="table table-bordered table-striped table-hover">
                 <thead>
                     <th>Item</th>
                     <th>Price</th>
                 </thead>
-                <tbody data-bind="foreach: ShardDeal.list[GameConstants.ShardTraderLocations[Wiki.pageName()]]()">
+                <tbody data-bind="foreach: ShardDeal.list[$data.location]()">
                     <tr>
                         <td class="align-middle">
                             <img width="24" class="me-1" data-bind="attr: { src: './pokeclicker/docs/' + $data.item.itemType.image }" />


### PR DESCRIPTION
Fixes two things:

- Galar fossil pokemon (e.g. Arctovish) listing Route 6 as the trader location instead of Stow-on-Side
- Town individual pages listing first shard trader only if multiple exist (Stow-on-Side may be the only town this occurs)