### PR TITLE
Added Stone Evolution to Pokémon with a location requirement

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -199,7 +199,7 @@
                             <a class="badge text-bg-secondary" data-bind="text: $data.basePokemon + `${$data.restrictions ? ' 🔒' : ''}`,
                             attr: { href: `#!Pokemon/${$data.basePokemon}` },
                             tooltip: {
-                                title: $data.restrictions.map(r => r.hint()).join('<br/>') ?? '',
+                                title: ($data.restrictions.map(r => r.hint()).join('<br/>') ?? '') + ($data.stone != null ? '<br/> Requires ' + ItemList[GameConstants.StoneType[$data.stone]]._displayName : ''),
                                 html: true,
                                 placement: 'bottom',
                                 trigger: 'hover'


### PR DESCRIPTION
Added Stone requirement to Pokémon that first require to be in a certain location to evolve, like Eevee to Leafeon using Leaf Stone only in Galar.
Before:
![bstone](https://user-images.githubusercontent.com/106291026/234041414-57bf8219-963c-418a-bd03-d936235ad98e.png)
Now:
![stone](https://user-images.githubusercontent.com/106291026/234041435-891a697a-7e02-4751-8923-a7f360823131.png)
