### PR TITLE
Fix evolution item shard deals

### DIFF
--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -87,7 +87,7 @@
     <!-- Shard Trade -->
     <div class="mt-3" data-bind="if: Object.values(ShardDeal.list).flatMap((d) => d()).find((d) => d.item.itemType.name == $data.name)">
         <h3>Can be traded for in the following towns:</h3>
-        <div data-bind="foreach: Object.values(TownList).filter(t => t.content.some(c => c instanceof ShardTraderShop && ShardDeal.list[c.location]().some(d => d.item.itemType.name == $data.name)))">
+        <div data-bind="foreach: Object.values(TownList).filter(t => t.content.some(c => c instanceof ShardTraderShop && ShardDeal.list[c.location]?.().some(d => d.item.itemType.name == $data.name)))">
             <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Towns/${$data.name}` }"></a>
         </div>
     </div>


### PR DESCRIPTION
Some evolution item pages such as Metal Coat and Razor Fang (anything available at a shard trader) aren't generating correctly after the latest update due to a Hisui shard trader being added to the game code but the associated deals not being initialized.