### PR TITLE
Wandering Pokémon

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -14246,6 +14246,12 @@ const searchOptions = [
     type: 'Temporary Battles',
     page: '',
   },
+  // Wandering Pokémon
+  {
+    display: 'Wandering Pokémon',
+    type: 'Wandering Pokémon',
+    page: '',
+  },
 ];
 // Differentiate our different links with the same name
 searchOptions.forEach(a => {

--- a/data/Farm/overview_description.md
+++ b/data/Farm/overview_description.md
@@ -18,7 +18,7 @@ Berries can be obtained by planting obtained Berries in special configurations. 
 
 Mulch and Berry Shovel can be bought in Goldenrod City, Mauville City, Hearthome City. Mulches can be applied to Berry plants to speed up growth (Boost Mulch), increase harvest yield (Rich Mulch), increase mutation chance (Surprise Mulch), or all the above with a slightly reduced boost for all three (Amaze Mulch). Berry Shovels can be used to clear occupied plots.
 
-The farm can also produce helpful effects (external auras) such as increasing egg steps for faster breeding and better shiny chance.
+The farm can also produce helpful effects (external auras) such as increasing egg steps for faster breeding and better shiny chance. It can also attract specific Pokémon which are referred to as [[Wandering Pokémon]].
 
 ## Mutating Berries
 

--- a/data/Wandering Pokémon/overview_description.md
+++ b/data/Wandering Pokémon/overview_description.md
@@ -1,0 +1,9 @@
+A Farm with at least one fully ripe Berry can attract Wandering Pokémon that are automatically caught without the use of a Poké Ball. Which Wandering Pokémon is attracted is based on Berry type and the farthest region you have progressed to, with all valid options having an equal chance to be encountered.
+
+Some Berries attract rare Pokémon that can be used strategically to complete a region's Pokédex.
+
+Wandering Pokémon also have a Base 1/1024 chance to be shiny. Attracting a shiny Wandering Pokémon when there is at least one open plot on the Farm plants a [[Berries/Starf]] Berry in that open plot.
+
+The base chance to encounter a Wandering Pokémon is 1/2000 every 1.5 seconds for every fully ripe Berry. [[Berries/Roseli]] Berries have an Attract Aura that can multiplicatively increase this chance for all currently grown Berries on the Farm. The formula is:
+
+**Encounter Chance** = (Attract Aura * Ripe Berries) / 2000

--- a/pages/Berries/overview.html
+++ b/pages/Berries/overview.html
@@ -4,6 +4,7 @@
             <tr>
                 <th class="col-1">ID</th>
                 <th class="col-1">Berry</th>
+                <th>Color</th>
                 <th>Exp</th>
                 <th>Harvest Amount</th>
                 <th>Farm Points</th>
@@ -17,6 +18,7 @@
                     <img height="30px" data-bind="attr: {src: './pokeclicker/docs/' + FarmController.getBerryImage($data.type)}"/>
                 </td>
                 <td data-bind="text: BerryType[$data.type]"></td>
+                <td data-bind="text: BerryColor[$data.color]"></td>
                 <td data-bind="text: $data.exp"></td>
                 <td data-bind="text: $data.harvestAmount"></td>
                 <td data-bind="attr: { 'data-sort': $data.farmValue }">

--- a/pages/Wandering Pokémon/overview.html
+++ b/pages/Wandering Pokémon/overview.html
@@ -1,0 +1,74 @@
+<div>
+    <h3>Base Wanderers</h3>
+    <p>Base Wanderers refer to Pokémon attracted by any berry. Unlike the other types of wanderers, the Pokémon in this list gain no EVs if captured using this method.</p>
+    <table class="table table-hover table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>Region</th>
+                <th>Pokémon</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: Berry.baseWander">
+            <tr>
+                <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[PokemonHelper.calcNativeRegion($data)])"></td>
+                <td>
+                    <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data).id + '.png'}" />
+                    <a data-bind="text: $data, attr: { href: `#!Pokemon/${$data}` }"></a>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <h3>Color Wanderers</h3>
+    <p>Color Wanderers refer to Pokémon attracted by a Berry's specific color. Check <a href="#!Berries">Berries</a> page to see each Berry's color.</p>
+    <table class="table table-hover table-bordered">
+        <thead>
+            <tr>
+                <th>Color</th>
+                <th>Region</th>
+                <th>Pokémon</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: Object.keys(Berry.colorWander)">
+            <!-- ko foreach: Berry.colorWander[$data] -->
+            <tr data-bind="style: { 'background-color': $parentContext.$index() % 2 == 0 ? 'rgba(0,0,0,.05)' : '' }">
+                <!-- ko if: $index() == 0 -->
+                <td class="align-middle" data-bind="text: BerryColor[$parent], attr: { rowspan: Berry.colorWander[$parent].length }"></td>
+                <!-- /ko -->
+                <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[PokemonHelper.calcNativeRegion($data)])"></td>
+                <td>
+                    <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data).id + '.png'}" />
+                    <a data-bind="text: $data, attr: { href: `#!Pokemon/${$data}` }"></a>
+                </td>
+            </tr>
+            <!-- /ko -->
+        </tbody>
+    </table>
+    <h3>Specific Berry Wanderers</h3>
+    <table class="table table-hover table-bordered table-striped">
+        <thead>
+            <tr>
+                <th>Berry</th>
+                <th>Region</th>
+                <th>Pokémon</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: App.game.farming.berryData">
+            <!-- ko foreach: $data.wander.filter((w) => !Berry.baseWander.some((b) => w === b)).filter((w) => !Berry.colorWander[$data.color].some((b) => w === b)) -->
+            <tr>
+                <td>
+                    <img height="30px" data-bind="attr: {src: './pokeclicker/docs/' + FarmController.getBerryImage($parent.type)}"/>
+                    <a data-bind="text: BerryType[$parent.type], attr: { href: `#!Berries/${[BerryType[$parent.type]]}` }"></a>
+                </td>
+                <td>
+                    <p data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[PokemonHelper.calcNativeRegion($data)])"></p>
+                </td>
+                <td>
+                    <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data).id + '.png'}" />
+                    <a data-bind="text: $data, attr: { href: `#!Pokemon/${$data}` }"></a>
+                    <br>
+                </td>
+            </tr>
+            <!-- /ko -->
+        </tbody>
+    </table>
+</div>

--- a/pages/Wandering Pokémon/overview.html
+++ b/pages/Wandering Pokémon/overview.html
@@ -43,7 +43,7 @@
             <!-- /ko -->
         </tbody>
     </table>
-    <h3>Specific Berry Wanderers</h3>
+    <h3>Berry-Specific Wanderers</h3>
     <table class="table table-hover table-bordered table-striped">
         <thead>
             <tr>

--- a/pages/Wandering Pokémon/overview.html
+++ b/pages/Wandering Pokémon/overview.html
@@ -53,7 +53,7 @@
             </tr>
         </thead>
         <tbody data-bind="foreach: App.game.farming.berryData">
-            <!-- ko foreach: $data.wander.filter((w) => !Berry.baseWander.some((b) => w === b)).filter((w) => !Berry.colorWander[$data.color].some((b) => w === b)) -->
+            <!-- ko foreach: $data.wander.filter((w) => !Berry.baseWander.some((b) => w === b) && !Berry.colorWander[$data.color].some((b) => w === b)) -->
             <tr>
                 <td>
                     <img height="30px" data-bind="attr: {src: './pokeclicker/docs/' + FarmController.getBerryImage($parent.type)}"/>

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -246,6 +246,12 @@ const searchOptions = [
     type: 'Temporary Battles',
     page: '',
   },
+  // Wandering Pokémon
+  {
+    display: 'Wandering Pokémon',
+    type: 'Wandering Pokémon',
+    page: '',
+  },
 ];
 // Differentiate our different links with the same name
 searchOptions.forEach(a => {


### PR DESCRIPTION
Adds a page with information about Wandering Pokémon. It lists the base wanderers, color wanderers, and specific wanderers.

To help people check which berry is which color, added the "Color" column to the main Berry page. No need to add it to individual berry pages since those already had the data.

Also added a link to this page to the Farm page.