### PR TITLE
Fix duplicates and filter DummyEvolutions in 'Evolves into' section

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -50,12 +50,12 @@
                 </tbody>
             </table>
         </div>
-        <div data-bind="visible: $data.evolutions">
+        <div data-bind="visible: $data.evolutions" class="mb-3">
             <h3>Evolves into:</h3>
-            <!-- ko foreach: $data.evolutions -->
+            <!-- ko foreach: [...new Set($data.evolutions?.map(e => e.evolvedPokemon))] -->
                 <a href="#!" class="badge text-bg-secondary" data-bind="
-                    attr: { href: `#!Pokemon/${$data.evolvedPokemon}` },
-                    text: $data.evolvedPokemon"></a>
+                    attr: { href: `#!Pokemon/${$data}` },
+                    text: $data"></a>
             <!-- /ko -->
         </div>
         <div data-bind="visible: Object.entries(PokemonHelper.getPokemonLocations($data.name)).length">

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -50,9 +50,9 @@
                 </tbody>
             </table>
         </div>
-        <div data-bind="visible: $data.evolutions" class="mb-3">
+        <div data-bind="visible: $data.evolutions.filter(e => e.trigger !== EvoTrigger.NONE)" class="mb-3">
             <h3>Evolves into:</h3>
-            <!-- ko foreach: [...new Set($data.evolutions?.map(e => e.evolvedPokemon))] -->
+            <!-- ko foreach: [...new Set($data.evolutions?.filter(e => e.trigger !== EvoTrigger.NONE).map(e => e.evolvedPokemon))] -->
                 <a href="#!" class="badge text-bg-secondary" data-bind="
                     attr: { href: `#!Pokemon/${$data}` },
                     text: $data"></a>


### PR DESCRIPTION
There can be duplicates listed in the 'Evolves into' section if an evolution has multiple ways it can be obtained. Eevee is a prime example of this (I'm not even sure if it affects any others).

Also filtered DummyEvolutions from being displayed (Doduo having Pinkan Dodrio listed, Milcery listing all Alcremie, etc.) and added a slight margin to the bottom of the section.


![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/a2d5a827-e732-4317-8bc0-8d51979a4b8a)
