### PR TITLE
Fix individual mega pages

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -199,7 +199,7 @@
                             <a class="badge text-bg-secondary" data-bind="text: $data.basePokemon + `${$data.restrictions ? ' 🔒' : ''}`,
                             attr: { href: `#!Pokemon/${$data.basePokemon}` },
                             tooltip: {
-                                title: ($data.restrictions.map(r => r.hint()).join('<br/>') ?? '') + ($data.stone != null ? '<br/> Requires ' + ItemList[GameConstants.StoneType[$data.stone]]._displayName : ''),
+                                title: ($data.restrictions.filter(r => !(r instanceof MegaEvolveRequirement)).map(r => r.hint()).join('<br/>') ?? '') + ($data.stone != null ? '<br/> Requires ' + ItemList[GameConstants.StoneType[$data.stone]]._displayName : ''),
                                 html: true,
                                 placement: 'bottom',
                                 trigger: 'hover'


### PR DESCRIPTION
There was a change in `MegaEvolveRequirement` which is causing an error on the individual Mega pokemon pages. There is already a fix merged in the game code but there most likely won't be an update any time soon. This is a temporary fix until the next game update so the pages are usable.