### PR TITLE
Fixed default BF calculator

### DIFF
--- a/pages/Battle Frontier/overview.html
+++ b/pages/Battle Frontier/overview.html
@@ -28,11 +28,11 @@
 <br>
 <div>
     <h3>Battle Frontier Statistics</h3>
-    <table class="table table-hover table-striped table-bordered" data-bind="with: { stage: ko.observable(100), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
+    <table class="table table-hover table-striped table-bordered" data-bind="with: { stage: ko.observable(1000), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
         <thead class="thead-dark">
             <tr>
                 <th>Level</th>
-                <th><input type="number" min="1" step="1" value="100" data-bind="event: { input: (data, e) => {
+                <th><input type="number" min="1" step="1" value="1000" data-bind="event: { input: (data, e) => {
                     BattleFrontierRunner.stage = ko.observable(+e.target.value);
                     BattleFrontierBattle.generateNewEnemy();
                     $data.stage(+e.target.value);

--- a/pages/Battle Frontier/overview.html
+++ b/pages/Battle Frontier/overview.html
@@ -28,16 +28,16 @@
 <br>
 <div>
     <h3>Battle Frontier Statistics</h3>
-    <table class="table table-hover table-striped table-bordered" data-bind="with: { stage: ko.observable(1000), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
+    <table class="table table-hover table-striped table-bordered" data-bind="with: { stage: ko.observable(BattleFrontierRunner.stage.peek()), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
         <thead class="thead-dark">
             <tr>
                 <th>Level</th>
-                <th><input type="number" min="1" step="1" value="1000" data-bind="event: { input: (data, e) => {
+                <th><input type="number" min="1" step="1" data-bind="event: { input: (data, e) => {
                     BattleFrontierRunner.stage = ko.observable(+e.target.value);
                     BattleFrontierBattle.generateNewEnemy();
                     $data.stage(+e.target.value);
                     $data.enemyPokemon(BattleFrontierBattle.enemyPokemon());
-                } }"/></th>
+                } }, value: $data.stage"/></th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
The BF calculator was loading stage 1k for some reason instead of stage 100 and thus showing a mix of stage 1k and 100 stats. Now it loads... stage 1k anyway but it shows the correct stats since the default has been changed to 1k.