### PR TITLE
Add Pokemon ID # to search

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -14053,7 +14053,7 @@ const searchOptions = [
     page: '',
   },
   ...Object.values(pokemonList).map(p => ({
-    display: p.name,
+    display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,
   })),

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -23,7 +23,7 @@ const searchOptions = [
     page: '',
   },
   ...Object.values(pokemonList).map(p => ({
-    display: p.name,
+    display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,
   })),


### PR DESCRIPTION
Adds the ability to search by pokemon ID #.

![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/dc08dfcc-50f6-4aea-80fe-930afb30f54c)
