### PR TITLE
Change safari pokemon list generation to Kanto only

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12429,7 +12429,7 @@ App.game.farming.initialize();
 App.game.breeding.initialize();
 App.game.oakItems.initialize();
 QuestLineHelper.loadQuestLines();
-SafariPokemonList.generateSafariLists();
+SafariPokemonList.generateKantoSafariList();
 BattleFrontierRunner.stage(100);
 BattleFrontierBattle.generateNewEnemy();
 

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -48,7 +48,7 @@ App.game.farming.initialize();
 App.game.breeding.initialize();
 App.game.oakItems.initialize();
 QuestLineHelper.loadQuestLines();
-SafariPokemonList.generateSafariLists();
+SafariPokemonList.generateKantoSafariList();
 BattleFrontierRunner.stage(100);
 BattleFrontierBattle.generateNewEnemy();
 


### PR DESCRIPTION
Generating the Friend Safari pokemon list causes a delay on the initial page load. There is no need to do this for the wiki so I've changed it to only generate the Kanto list.