### PR TITLE
Update quest line step list

### DIFF
--- a/pages/Quest Lines/main.html
+++ b/pages/Quest Lines/main.html
@@ -8,13 +8,16 @@
         <div data-bind="text: $data.description"></div>
         <h3>Quest Steps</h3>
         <ol class="list-group list-group-numbered" data-bind="foreach: $data.quests()">
-            <!-- ko if: $data.description -->
-            <li class="list-group-item" data-bind="text: $data.description"></li>
-            <!-- /ko -->
             <!-- ko if: $data.quests -->
-            <li class="list-group-item" data-bind="foreach: $data.quests">
-                <span data-bind="text: $data.description"></span><br/>
+            <li class="list-group-item">
+                <span data-bind="text: $data.description"></span>
+                <ul data-bind="foreach: $data.quests">
+                    <li data-bind="text: $data.description"></li>
+                </ul>
             </li>
+            <!-- /ko -->
+            <!-- ko ifnot: $data.quests -->
+            <li class="list-group-item" data-bind="text: $data.description"></li>
             <!-- /ko -->
         </ol>
     </div>


### PR DESCRIPTION
The quest line step list was displaying steps with sub-quests as two separate steps - first was the overall description and second was the description of each sub-quest.