### PR TITLE
Add dungeon chest drop chance table to Item pages

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -13441,6 +13441,7 @@ const getDungeonLootChancesForItem = (itemName) => {
     const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
     const lootName = item.displayName;
 
+    // Collate and flatten all item-specific data from each dungeon's loot tables
     const itemData = [];
     for (let dungeon of dungeonsWithLootTables) {
         for (let tier of dungeon.lootTable) {
@@ -13455,6 +13456,16 @@ const getDungeonLootChancesForItem = (itemName) => {
                     itemData.push(itemDungeonData);
                 }
             }
+        }
+    }
+
+    // If some of the dungeons had hasItemsThatIgnoreDebuff, fill all itemChances to have 8 items
+    if (itemData.some((item) => item.chances.length > 5)) {
+        for (let data of itemData) {
+            const chances = data.chances;
+            const length = chances.length
+            const lastIndex = length - 1;
+            data.chances = Array(8).fill(chances[lastIndex]).toSpliced(0, length, ...chances);
         }
     }
 

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -94,7 +94,7 @@
         <div class="table-responsive">
             <table class="table table-hover table-striped table-bordered" data-bind="with: Wiki.dungeons.getDungeonLootChancesForItem($data.name), as: 'itemChances'">
                 <thead class="thead-dark">
-                    <tr data-bind="using: itemChances.some((item) => item.chances.length > 5), as: 'hasItemsThatIgnoreDebuff'">
+                    <tr data-bind="using: itemChances.some((item) => item.chances.length > 5), as: 'hasFullDebuffColumns'">
                         <th>Dungeon</th>
                         <th>Region</th>
                         <th class="text-center">Chest</th>
@@ -102,13 +102,13 @@
                         <th>100 Clears</th>
                         <th>250 Clears</th>
                         <th>500 Clears</th>
-                        <!-- ko if: hasItemsThatIgnoreDebuff -->
+                        <!-- ko if: hasFullDebuffColumns -->
                         <th>Debuffed (0&nbsp;Clears)</th>
                         <th>Debuffed (100&nbsp;Clears)</th>
                         <th>Debuffed (250&nbsp;Clears)</th>
                         <th>Debuffed (500&nbsp;Clears)</th>
                         <!-- /ko -->
-                        <!-- ko ifnot: hasItemsThatIgnoreDebuff -->
+                        <!-- ko ifnot: hasFullDebuffColumns -->
                         <th>Debuffed</th>
                         <!-- /ko -->
                         <!-- ko if: itemChances.some((item) => item.requirement) -->

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -90,9 +90,44 @@
     </div>
     <div class="mt-3" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name)))">
         <h3>Can be found in the following dungeons:</h3>
-        <!-- ko foreach : Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name))) -->
-        <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Dungeons/${$data.name}` }"></a>
-        <!-- /ko -->
+        <p>Chance shown is for any given chest in the dungeon to contain the item.</p>
+        <div class="table-responsive">
+            <table class="table table-hover table-striped table-bordered" data-bind="with: Wiki.dungeons.getDungeonLootChancesForItem($data.name), as: 'itemChances'">
+                <thead class="thead-dark">
+                    <tr>
+                        <th>Dungeon</th>
+                        <th>Region</th>
+                        <th class="text-center">Chest</th>
+                        <th>0 Clears</th>
+                        <th>100 Clears</th>
+                        <th>250 Clears</th>
+                        <th>500 Clears</th>
+                        <th>Debuffed</th>
+                        <!-- ko if: itemChances.some((item) => item.requirement) -->
+                        <th>Requirement</th>
+                        <!-- /ko -->
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- ko foreach: itemChances -->
+                    <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Dungeons', $data.dungeonName); return false; }">
+                        <td data-bind="text: $data.dungeonName"></td>
+                        <td data-bind="text: $data.region"></td>
+                        <!-- <td data-bind="text: $data.tier"></td> -->
+                        <td class="text-center">
+                            <img width="40px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/dungeons/chest-${$data.tier}.png` }"/>
+                        </td>
+                        <!-- ko foreach: $data.chances.slice(0, 5) -->
+                        <td data-bind="text: typeof $data.chance === 'number' ? ($data.chance >= 0.0001 ? $data.chance.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }) : ('<' + 0.0001.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }))) : ($data.chance ?? '-')"></td>
+                        <!-- /ko -->
+                        <!-- ko if: itemChances.some((item) => item.requirement) -->
+                        <td data-bind="text: $data.requirement ?? '-'"></td>
+                        <!-- /ko -->
+                    </tr>
+                    <!-- /ko -->
+                </tbody>
+            </table>
+        </div>
     </div>
     <div class="mt-3" data-bind="if: pokemonList.some((p) => ([ItemType.item, ItemType.underground]).includes(p.heldItem?.type) && p.heldItem?.id == $data.name)">
         <h3>Can be dropped by the following Pokémon:</h3>

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -88,13 +88,13 @@
             <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Towns/${$data.name}` }"></a>
         </div>
     </div>
-    <div class="mt-3" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name)))">
+    <div class="mt-3" style="clear: right;" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name)))">
         <h3>Can be found in the following dungeons:</h3>
         <p>Chance shown is for any given chest in the dungeon to contain the item.</p>
         <div class="table-responsive">
             <table class="table table-hover table-striped table-bordered" data-bind="with: Wiki.dungeons.getDungeonLootChancesForItem($data.name), as: 'itemChances'">
                 <thead class="thead-dark">
-                    <tr>
+                    <tr data-bind="using: itemChances.some((item) => item.chances.length > 5), as: 'hasItemsThatIgnoreDebuff'">
                         <th>Dungeon</th>
                         <th>Region</th>
                         <th class="text-center">Chest</th>
@@ -102,7 +102,15 @@
                         <th>100 Clears</th>
                         <th>250 Clears</th>
                         <th>500 Clears</th>
+                        <!-- ko if: hasItemsThatIgnoreDebuff -->
+                        <th>Debuffed (0&nbsp;Clears)</th>
+                        <th>Debuffed (100&nbsp;Clears)</th>
+                        <th>Debuffed (250&nbsp;Clears)</th>
+                        <th>Debuffed (500&nbsp;Clears)</th>
+                        <!-- /ko -->
+                        <!-- ko ifnot: hasItemsThatIgnoreDebuff -->
                         <th>Debuffed</th>
+                        <!-- /ko -->
                         <!-- ko if: itemChances.some((item) => item.requirement) -->
                         <th>Requirement</th>
                         <!-- /ko -->
@@ -113,11 +121,10 @@
                     <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Dungeons', $data.dungeonName); return false; }">
                         <td data-bind="text: $data.dungeonName"></td>
                         <td data-bind="text: $data.region"></td>
-                        <!-- <td data-bind="text: $data.tier"></td> -->
                         <td class="text-center">
                             <img width="40px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/dungeons/chest-${$data.tier}.png` }"/>
                         </td>
-                        <!-- ko foreach: $data.chances.slice(0, 5) -->
+                        <!-- ko foreach: $data.chances -->
                         <td data-bind="text: typeof $data.chance === 'number' ? ($data.chance >= 0.0001 ? $data.chance.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }) : ('<' + 0.0001.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }))) : ($data.chance ?? '-')"></td>
                         <!-- /ko -->
                         <!-- ko if: itemChances.some((item) => item.requirement) -->

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -4,6 +4,7 @@ const getTableClearCounts = (dungeon) => {
     }
 
     const hasItemsThatIgnoreDebuff = Object.values(dungeon.lootTable).flat().some(item => item.ignoreDebuff);
+    const hasItemsWithClearRequirements = Object.values(dungeon.lootTable).flat().some(item => item.requirement instanceof ClearDungeonRequirement);
 
     const tableClearCounts = [
         {
@@ -28,7 +29,7 @@ const getTableClearCounts = (dungeon) => {
         }
     ];
 
-    if (hasItemsThatIgnoreDebuff) {
+    if (hasItemsThatIgnoreDebuff || hasItemsWithClearRequirements) {
         tableClearCounts.push(...tableClearCounts.map(clearSetup => ({...clearSetup, debuff: true, header: `Debuffed (${clearSetup.header})`})))
     } else {
         tableClearCounts.push({
@@ -267,6 +268,20 @@ const getDungeonLootChancesForItem = (itemName) => {
                 }
             }
         }
+    }
+
+    var hasMeaningfullyDifferentDebuffChances = itemData.some((item) => {
+        const debuffChances = item.chances.filter((chance) => chance.debuff).map((chance) => chance.chance ?? 0);
+        const max = Math.max(...debuffChances);
+        const min = Math.min(...debuffChances);
+        const goesFromZeroToNonZero = (min == 0 && max != 0);
+        const visibleDifferenceBetweenOdds = (max - min > 0.00005);
+        return goesFromZeroToNonZero || visibleDifferenceBetweenOdds;
+    });
+
+    if (!hasMeaningfullyDifferentDebuffChances) {
+        itemData.map((item) => item.chances = item.chances.slice(0, 5));
+        return itemData;
     }
 
     // If some of the dungeons had hasItemsThatIgnoreDebuff, fill all itemChances to have 8 items

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -185,6 +185,10 @@ const getLootTierWeights = (dungeon, clears, debuffed, requirement = () => true)
 };
 
 const getDungeonLoot = (dungeon) => {
+    if (getDungeonLoot.cache.has(dungeon)) {
+        return getDungeonLoot.cache.get(dungeon);
+    }
+
     const tableClearCounts = getTableClearCounts(dungeon)
     const tierWeights = tableClearCounts.map(clearSetup => getLootTierWeights(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
     const itemChanceMaps = tableClearCounts.map(clearSetup => getDungeonLootChances(dungeon, clearSetup.clears, clearSetup.debuff, checkLootRequirements(dungeon, clearSetup)));
@@ -230,8 +234,42 @@ const getDungeonLoot = (dungeon) => {
         }
         lootTiers.push(tierData);
     }
+    getDungeonLoot.cache.set(dungeon, lootTiers);
+
     return lootTiers;
 };
+getDungeonLoot.cache = new WeakMap();
+
+const getDungeonLootChancesForItem = (itemName) => {
+    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
+    const dungeonsWithLootTables = dungeonsDroppingItem.map(dungeon => (
+        {
+            dungeonName: dungeon.name,
+            lootTable: getDungeonLoot(dungeon)
+        }
+    ));
+    const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
+    const lootName = item.displayName;
+
+    const itemData = [];
+    for (let dungeon of dungeonsWithLootTables) {
+        for (let tier of dungeon.lootTable) {
+            for (let loot of tier.items) {
+                if (loot.item == lootName) {
+                    const itemDungeonData = {
+                        dungeonName: dungeon.dungeonName,
+                        region: GameConstants.camelCaseToString(GameConstants.Region[GameConstants.getDungeonRegion(dungeon.dungeonName)]),
+                        tier: tier.tier,
+                        ...loot
+                    }
+                    itemData.push(itemDungeonData);
+                }
+            }
+        }
+    }
+
+    return itemData;
+}
 
 const hasLootWithRequirements = (dungeon) => {
     if (hasLootWithRequirements.cache.has(dungeon)) {
@@ -253,6 +291,7 @@ hasLootWithRequirements.cache = new WeakMap();
 module.exports = {
     getDungeonLoot,
     getDungeonLootChances,
+    getDungeonLootChancesForItem,
     hasLootWithRequirements,
     getTableClearCounts,
     itemTypeCategories

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -251,6 +251,7 @@ const getDungeonLootChancesForItem = (itemName) => {
     const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
     const lootName = item.displayName;
 
+    // Collate and flatten all item-specific data from each dungeon's loot tables
     const itemData = [];
     for (let dungeon of dungeonsWithLootTables) {
         for (let tier of dungeon.lootTable) {
@@ -265,6 +266,16 @@ const getDungeonLootChancesForItem = (itemName) => {
                     itemData.push(itemDungeonData);
                 }
             }
+        }
+    }
+
+    // If some of the dungeons had hasItemsThatIgnoreDebuff, fill all itemChances to have 8 items
+    if (itemData.some((item) => item.chances.length > 5)) {
+        for (let data of itemData) {
+            const chances = data.chances;
+            const length = chances.length
+            const lastIndex = length - 1;
+            data.chances = Array(8).fill(chances[lastIndex]).toSpliced(0, length, ...chances);
         }
     }
 


### PR DESCRIPTION
Consolidates the relevant information available on each of the Dungeon pages into the Item page itself, so you don't need to navigate to each Dungeon page to see the region/drop chance/etc.

Examples:
No requirements:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/a1ae23d0-a774-468e-bca2-90b9c10c33d9)

With requirements:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/ced00499-6b89-4c54-8f7d-336003081d37)

More than 40 rows and becoming a datatable:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/08531661-f1ae-492a-9310-566dc82b2281)