### PR TITLE
More explicit Mega Stone information

### DIFF
--- a/pages/Mega Pokémon/overview.html
+++ b/pages/Mega Pokémon/overview.html
@@ -34,19 +34,19 @@ const megaInfo = {
     },
     'Mega Blastoise': {
         megaStone: 'Blastoisinite',
-        method: `Purchasable with 250,000 Water Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]]. Free if [[Pokémon/Squirtle]] was picked as the Kanto starter.`,
+        method: `Purchasable with 250,000 Water Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Squirtle]] was picked as the Kanto starter.`,
     },
     'Mega Charizard X': {
         megaStone: 'Charizardite X',
-        method: `Purchasable with 125,000 Fire and Dragon Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]].`,
+        method: `Purchasable with 125,000 Fire and Dragon Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]].`,
     },
     'Mega Charizard Y': {
         megaStone: 'Charizardite Y',
-        method: `Purchasable with 125,000 Fire and Flying Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]]. Free if [[Pokémon/Charmander]] was picked as the Kanto starter.`,
+        method: `Purchasable with 125,000 Fire and Flying Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Charmander]] was picked as the Kanto starter.`,
     },
     'Mega Venusaur': {
         megaStone: 'Venusaurite',
-        method: `Purchasable with 125,000 Grass and Poison Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]]. Free if [[Pokémon/Bulbasaur]] was picked as the Kanto starter.`,
+        method: `Purchasable with 125,000 Grass and Poison Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Bulbasaur]] was picked as the Kanto starter.`,
     },
     'Mega Pinsir': {
         megaStone: 'Pinsirite',
@@ -62,15 +62,15 @@ const megaInfo = {
     },
     'Mega Blaziken': {
         megaStone: 'Blazikenite',
-        method: `Purchasable with 125,000 Fire and Fighting Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]]. Free if [[Pokémon/Torchic]] was picked as the Hoenn starter.`,
+        method: `Purchasable with 125,000 Fire and Fighting Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Torchic]] was picked as the Hoenn starter.`,
     },
     'Mega Swampert': {
         megaStone: 'Swampertite',
-        method: `Purchasable with 125,000 Water and Ground Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]]. Free if [[Pokémon/Mudkip]] was picked as the Hoenn starter.`,
+        method: `Purchasable with 125,000 Water and Ground Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Mudkip]] was picked as the Hoenn starter.`,
     },
     'Mega Sceptile': {
         megaStone: 'Sceptilite',
-        method: `Purchasable with 125,000 Grass and 125,000 Dragon Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]]. Free if [[Pokémon/Treecko]] was picked as the Hoenn starter.`,
+        method: `Purchasable with 125,000 Grass and 125,000 Dragon Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Treecko]] was picked as the Hoenn starter.`,
     },
     'Mega Slowbro': {
         megaStone: 'Slowbronite',

--- a/pages/Mega Pokémon/overview.html
+++ b/pages/Mega Pokémon/overview.html
@@ -106,15 +106,15 @@ const megaInfo = {
     },
     'Mega Houndoom': {
         megaStone: 'Houndoominite',
-        method: `Battle [[Temporary Battles/Wild Houndour Horde]] near [[Routes/Kalos Route 16]], in Sunny [[Weather]]. Must have captured at least 500 [[Pokémon/Houndour]] for the encounter to appear.`,
+        method: `Battle [[Temporary Battles/Wild Houndour Horde]] near [[Routes/Kalos Route 16]], in Sunny [[Weather]]. Must have captured at least 500 [[Pokémon/Houndour]] and become Kalos Champion for the encounter to appear.`,
     },
     'Mega Tyranitar': {
         megaStone: 'Tyranitarite',
-        method: `Clear [[Gyms/Cyllage City]]'s Gym 2000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]].`,
+        method: `Clear [[Gyms/Cyllage City]]'s Gym 2000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
     },
     'Mega Gardevoir': {
         megaStone: 'Gardevoirite',
-        method: `Battle [[Temporary Battles/Grand Duchess Diantha]] in [[Towns/Lumiose City]].`,
+        method: `Battle [[Temporary Battles/Grand Duchess Diantha]] in [[Towns/Lumiose City]] after becoming Kalos Champion.`,
     },
     'Mega Sableye': {
         megaStone: 'Sablenite',
@@ -126,11 +126,11 @@ const megaInfo = {
     },
     'Mega Aggron': {
         megaStone: 'Aggronite',
-        method: `Clear [[Gyms/Cyllage City]]'s Gym 2,000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]].`,
+        method: `Clear [[Gyms/Cyllage City]]'s Gym 2,000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
     },
     'Mega Manectric': {
         megaStone: 'Manectite',
-        method: `Battle [[Temporary Battles/Wild Electrike Horde]] near [[Routes/Kalos Route 16]], in Thunderstorm [[Weather]]. Must have captured at least 500 [[Pokémon/Electrike]] for the encounter to appear.`,
+        method: `Battle [[Temporary Battles/Wild Electrike Horde]] near [[Routes/Kalos Route 16]], in Thunderstorm [[Weather]]. Must have captured at least 500 [[Pokémon/Electrike]] and become Kalos Champion for the encounter to appear.`,
     },
     'Mega Sharpedo': {
         megaStone: 'Sharpedonite',
@@ -142,7 +142,7 @@ const megaInfo = {
     },
     'Mega Absol': {
         megaStone: 'Absolite',
-        method: `Battle [[Temporary Battles/Calem 6]] in [[Towns/Kiloude City]].`,
+        method: `Battle [[Temporary Battles/Calem 6]] in [[Towns/Kiloude City]] after becoming Kalos Champion.`,
     },
     'Mega Glalie': {
         megaStone: 'Glalitite',


### PR DESCRIPTION
Added Kalos Champion requirement to the respective Mega Stones that need it for the temporary battle to appear. Also added the relevant quest line to the Stone Salesmen that need it for that one to appear as well. Words.