### PR TITLE
Apply middle alignment to markdown table cells

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12800,6 +12800,10 @@ md.renderer.rules.table_open = (tokens, idx, options, env, self) => {
 md.renderer.rules.table_close = (tokens, idx, options, env, self) => {
   return '</table></div>';
 };
+md.renderer.rules.td_open = (tokens, idx, options, env, self) => {
+  tokens[idx].attrPush(['class', 'align-middle']);
+  return proxy(tokens, idx, options, env, self);
+};
 
 module.exports = {
   md,

--- a/scripts/markdown-renderer.js
+++ b/scripts/markdown-renderer.js
@@ -60,6 +60,10 @@ md.renderer.rules.table_open = (tokens, idx, options, env, self) => {
 md.renderer.rules.table_close = (tokens, idx, options, env, self) => {
   return '</table></div>';
 };
+md.renderer.rules.td_open = (tokens, idx, options, env, self) => {
+  tokens[idx].attrPush(['class', 'align-middle']);
+  return proxy(tokens, idx, options, env, self);
+};
 
 module.exports = {
   md,


### PR DESCRIPTION
Applies middle alignment to (all) markdown table cells.

Before:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/8db98a21-97b2-455f-9188-cf8fc97f98ee)

After:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/07d3aa7c-56bb-4e8d-8432-a6ec3b972d44)
