### PR TITLE
Better evolution hints

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12536,8 +12536,149 @@ const requirementHints = (requirement, includeMarkdown = true) => {
     return hints;
 };
 
+const getEvolutionHints = (evoData) => {
+    if (!evoData) {
+        return [];
+    }
+
+    const hints = [];
+    const restrictions = evoData.restrictions;
+    const listFormatter = new Intl.ListFormat('en', { type: 'disjunction' });
+
+    let hint = '';
+    // Base Evo type (Level or Stone)
+    if (isLevelEvolution(evoData)) {
+        const levelReq = getRequirementFromRestrictions(restrictions, 'PokemonLevelRequirement');
+        hint = levelReq.requiredValue == 1 ? `Hatch ${levelReq.pokemon}` : `${levelReq.pokemon} must reach level ${levelReq.requiredValue}`;
+    } else if (isStoneEvolution(evoData)) {
+        const stone = ItemList[GameConstants.StoneType[evoData.stone]]._displayName;
+        hint = `Requires using ${GameHelper.anOrA(stone)} ${stone}`;
+    }
+
+    // Additional restrictions
+    if (isDungeonRestrictedEvolution(evoData)) {
+        const dungeonReq = getRequirementFromRestrictions(restrictions, 'InDungeonRequirement');
+        hint += ` in the ${dungeonReq.dungeon} dungeon`;
+    }
+
+    if (isTimeRestrictedEvolution(evoData)) {
+        const timeReq = getRequirementFromRestrictions(restrictions, 'DayCyclePartRequirement');
+        hint += ` while the time is ${listFormatter.format(timeReq.dayCycleParts.map((t) => DayCyclePart[t]))}`;
+    }
+
+    if (isEnvironmentRestrictedEvolution(evoData)) {
+        const envReq = getRequirementFromRestrictions(restrictions, 'InEnvironmentRequirement');
+        hint += ` in ${GameHelper.anOrA(envReq.environment)} ${envReq.environment} environment`;
+    }
+
+    if (isQuestLineRestrictedEvolution(evoData)) {
+        const questReq = getRequirementFromRestrictions(restrictions, 'QuestLineRequirement');
+        hint += ` after completing the ${questReq.questLineName} quest line`;
+    };
+
+    if (isInRegionRestrictedEvolution(evoData)) {
+        const inRegionReq = getRequirementFromRestrictions(restrictions, 'InRegionRequirement');
+        hint += ` in the ${listFormatter.format(inRegionReq.regions.map(r => getRegionName(r)))} region`;
+    }
+
+    if (isWeatherRestrictedEvolution(evoData)) {
+        const weatherReq = getRequirementFromRestrictions(restrictions, 'WeatherRequirement');
+        hint += ` during ${listFormatter.format(weatherReq.weather.map(w => WeatherType[w]))} weather`;
+    }
+
+    if (isHeldItemRestrictedEvolution(evoData)) {
+        const itemReq = getRequirementFromRestrictions(restrictions, 'HoldingItemRequirement');
+        hint += ` while holding ${GameHelper.anOrA(itemReq.itemName)} ${GameConstants.humanifyString(itemReq.itemName)}`;
+    }
+
+    if (isMegaEvolution(evoData)) {
+        const megaReq = getRequirementFromRestrictions(restrictions, 'MegaEvolveRequirement');
+        const requiredAttack = pokemonMap[megaReq.name].attack * GameConstants.MEGA_REQUIRED_ATTACK_MULTIPLIER;
+        hint += ` after obtaining ${GameConstants.humanifyString(GameConstants.MegaStoneType[megaReq.megaStone])} and ${megaReq.name} has ${requiredAttack.toLocaleString()} or more attack`;
+    }
+
+    if (hint.length) {
+        hints.push(`${hint}.`);
+    }
+
+    if (hints.length) {
+        // Max Region restriction, skipping if Kanto
+        const maxRegionReq = getRequirementFromRestrictions(restrictions, 'MaxRegionRequirement');
+        if (maxRegionReq && maxRegionReq.requiredValue != GameConstants.Region.kanto) {
+            hints.push(`You must have reached the ${getRegionName(maxRegionReq.requiredValue)} region.`);
+        }
+    } else {
+        // Default to standard hints if not covered here
+        hints.push(...restrictions.map(r => r.hint()));
+    }
+
+    return hints;
+};
+
+const isLevelEvolution = (evoData) => {
+    return evoData.trigger == EvoTrigger.LEVEL;
+}
+
+const isStoneEvolution = (evoData) => {
+    return evoData.trigger == EvoTrigger.STONE;
+};
+
+const isDungeonRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InDungeonRequirement']);
+};
+
+const isTimeRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['DayCyclePartRequirement']);
+};
+
+const isEnvironmentRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InEnvironmentRequirement']);
+};
+
+const isQuestLineRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['QuestLineRequirement']);
+}
+
+const isInRegionRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InRegionRequirement']);
+};
+
+const isWeatherRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['WeatherRequirement']);
+};
+
+const isHeldItemRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['HoldingItemRequirement']);
+};
+
+const isMegaEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['MegaEvolveRequirement']);
+};
+
+const hasEvoRestrictions = (restrictions, requirements) => {
+    return requirements.every(req => restrictions.some(res => res.constructor.name == req));
+};
+
+const getRequirementFromRestrictions = (restrictions, name) => {
+    const req = restrictions.find(res => {
+        if (res.constructor.name == 'LazyRequirementWrapper') {
+            return res.unwrap().constructor.name == name;
+        }
+
+        return res.constructor.name == name;
+    });
+
+    return req?.req ?? req;
+};
+
+const getRegionName = (region) => {
+    return GameConstants.camelCaseToString(GameConstants.Region[region]);
+};
+
 module.exports = {
     requirementHints,
+    getEvolutionHints,
+    getRegionName,
 }
 
 },{}],106:[function(require,module,exports){

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -199,7 +199,7 @@
                             <a class="badge text-bg-secondary" data-bind="text: $data.basePokemon + `${$data.restrictions ? ' 🔒' : ''}`,
                             attr: { href: `#!Pokemon/${$data.basePokemon}` },
                             tooltip: {
-                                title: ($data.restrictions.filter(r => !(r instanceof MegaEvolveRequirement)).map(r => r.hint()).join('<br/>') ?? '') + ($data.stone > -1 ? '<br/> Requires ' + ItemList[GameConstants.StoneType[$data.stone]]._displayName : ''),
+                                title: Wiki.gameHelper.getEvolutionHints($data).join('<br/>') ?? '',
                                 html: true,
                                 placement: 'bottom',
                                 trigger: 'hover'

--- a/scripts/gameHelper.js
+++ b/scripts/gameHelper.js
@@ -49,6 +49,147 @@ const requirementHints = (requirement, includeMarkdown = true) => {
     return hints;
 };
 
+const getEvolutionHints = (evoData) => {
+    if (!evoData) {
+        return [];
+    }
+
+    const hints = [];
+    const restrictions = evoData.restrictions;
+    const listFormatter = new Intl.ListFormat('en', { type: 'disjunction' });
+
+    let hint = '';
+    // Base Evo type (Level or Stone)
+    if (isLevelEvolution(evoData)) {
+        const levelReq = getRequirementFromRestrictions(restrictions, 'PokemonLevelRequirement');
+        hint = levelReq.requiredValue == 1 ? `Hatch ${levelReq.pokemon}` : `${levelReq.pokemon} must reach level ${levelReq.requiredValue}`;
+    } else if (isStoneEvolution(evoData)) {
+        const stone = ItemList[GameConstants.StoneType[evoData.stone]]._displayName;
+        hint = `Requires using ${GameHelper.anOrA(stone)} ${stone}`;
+    }
+
+    // Additional restrictions
+    if (isDungeonRestrictedEvolution(evoData)) {
+        const dungeonReq = getRequirementFromRestrictions(restrictions, 'InDungeonRequirement');
+        hint += ` in the ${dungeonReq.dungeon} dungeon`;
+    }
+
+    if (isTimeRestrictedEvolution(evoData)) {
+        const timeReq = getRequirementFromRestrictions(restrictions, 'DayCyclePartRequirement');
+        hint += ` while the time is ${listFormatter.format(timeReq.dayCycleParts.map((t) => DayCyclePart[t]))}`;
+    }
+
+    if (isEnvironmentRestrictedEvolution(evoData)) {
+        const envReq = getRequirementFromRestrictions(restrictions, 'InEnvironmentRequirement');
+        hint += ` in ${GameHelper.anOrA(envReq.environment)} ${envReq.environment} environment`;
+    }
+
+    if (isQuestLineRestrictedEvolution(evoData)) {
+        const questReq = getRequirementFromRestrictions(restrictions, 'QuestLineRequirement');
+        hint += ` after completing the ${questReq.questLineName} quest line`;
+    };
+
+    if (isInRegionRestrictedEvolution(evoData)) {
+        const inRegionReq = getRequirementFromRestrictions(restrictions, 'InRegionRequirement');
+        hint += ` in the ${listFormatter.format(inRegionReq.regions.map(r => getRegionName(r)))} region`;
+    }
+
+    if (isWeatherRestrictedEvolution(evoData)) {
+        const weatherReq = getRequirementFromRestrictions(restrictions, 'WeatherRequirement');
+        hint += ` during ${listFormatter.format(weatherReq.weather.map(w => WeatherType[w]))} weather`;
+    }
+
+    if (isHeldItemRestrictedEvolution(evoData)) {
+        const itemReq = getRequirementFromRestrictions(restrictions, 'HoldingItemRequirement');
+        hint += ` while holding ${GameHelper.anOrA(itemReq.itemName)} ${GameConstants.humanifyString(itemReq.itemName)}`;
+    }
+
+    if (isMegaEvolution(evoData)) {
+        const megaReq = getRequirementFromRestrictions(restrictions, 'MegaEvolveRequirement');
+        const requiredAttack = pokemonMap[megaReq.name].attack * GameConstants.MEGA_REQUIRED_ATTACK_MULTIPLIER;
+        hint += ` after obtaining ${GameConstants.humanifyString(GameConstants.MegaStoneType[megaReq.megaStone])} and ${megaReq.name} has ${requiredAttack.toLocaleString()} or more attack`;
+    }
+
+    if (hint.length) {
+        hints.push(`${hint}.`);
+    }
+
+    if (hints.length) {
+        // Max Region restriction, skipping if Kanto
+        const maxRegionReq = getRequirementFromRestrictions(restrictions, 'MaxRegionRequirement');
+        if (maxRegionReq && maxRegionReq.requiredValue != GameConstants.Region.kanto) {
+            hints.push(`You must have reached the ${getRegionName(maxRegionReq.requiredValue)} region.`);
+        }
+    } else {
+        // Default to standard hints if not covered here
+        hints.push(...restrictions.map(r => r.hint()));
+    }
+
+    return hints;
+};
+
+const isLevelEvolution = (evoData) => {
+    return evoData.trigger == EvoTrigger.LEVEL;
+}
+
+const isStoneEvolution = (evoData) => {
+    return evoData.trigger == EvoTrigger.STONE;
+};
+
+const isDungeonRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InDungeonRequirement']);
+};
+
+const isTimeRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['DayCyclePartRequirement']);
+};
+
+const isEnvironmentRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InEnvironmentRequirement']);
+};
+
+const isQuestLineRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['QuestLineRequirement']);
+}
+
+const isInRegionRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['InRegionRequirement']);
+};
+
+const isWeatherRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['WeatherRequirement']);
+};
+
+const isHeldItemRestrictedEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['HoldingItemRequirement']);
+};
+
+const isMegaEvolution = (evoData) => {
+    return hasEvoRestrictions(evoData.restrictions, ['MegaEvolveRequirement']);
+};
+
+const hasEvoRestrictions = (restrictions, requirements) => {
+    return requirements.every(req => restrictions.some(res => res.constructor.name == req));
+};
+
+const getRequirementFromRestrictions = (restrictions, name) => {
+    const req = restrictions.find(res => {
+        if (res.constructor.name == 'LazyRequirementWrapper') {
+            return res.unwrap().constructor.name == name;
+        }
+
+        return res.constructor.name == name;
+    });
+
+    return req?.req ?? req;
+};
+
+const getRegionName = (region) => {
+    return GameConstants.camelCaseToString(GameConstants.Region[region]);
+};
+
 module.exports = {
     requirementHints,
+    getEvolutionHints,
+    getRegionName,
 }


### PR DESCRIPTION
Replaces the standard evolution restriction hints to be more user-friendly and informative.

Examples (before -> after):

![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/049ef97f-d84b-4839-8f64-079130ed868f)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/2e0561fb-7f40-4499-90a8-44cea9d06612)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/447f9e21-16f6-495f-ac88-a239e9068ecf)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/d6e52456-40ce-44fa-98dd-29280c474696)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/3e7a261e-41ab-423e-a732-9b99c25678f9)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/9cb08abf-bc3d-430c-ae72-8a0fd1c311a5)
