### PR TITLE
Set all badges to obtained

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -12434,6 +12434,9 @@ SafariPokemonList.generateKantoSafariList();
 BattleFrontierRunner.stage(100);
 BattleFrontierBattle.generateNewEnemy();
 
+// Set all badges to obtained for (daily deal) requirements
+App.game.badgeCase.badgeList.forEach(b => b(true));
+
 const now = new Date();
 DailyDeal.generateDeals(5, now);
 BerryDeal.generateDeals(now);

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -53,6 +53,9 @@ SafariPokemonList.generateKantoSafariList();
 BattleFrontierRunner.stage(100);
 BattleFrontierBattle.generateNewEnemy();
 
+// Set all badges to obtained for (daily deal) requirements
+App.game.badgeCase.badgeList.forEach(b => b(true));
+
 const now = new Date();
 DailyDeal.generateDeals(5, now);
 BerryDeal.generateDeals(now);


### PR DESCRIPTION
Calcium and Carbos were added to the Sinnoh berry deal with gym badge requirements. Obviously the wiki does not have these gym badges so the daily deal for this trader was off.

This sets all badges to obtained.