### PR TITLE
Filter pokemon items from search

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -14341,7 +14341,7 @@ const searchOptions = [
     type: 'Items',
     page: '',
   },
-  ...Object.values(ItemList).map(i => ({
+  ...Object.values(ItemList).filter(i => !(i instanceof PokemonItem)).map(i => ({
     display: i.displayName,
     type: 'Items',
     page: i.displayName,

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -77,7 +77,7 @@ const searchOptions = [
     type: 'Items',
     page: '',
   },
-  ...Object.values(ItemList).map(i => ({
+  ...Object.values(ItemList).filter(i => !(i instanceof PokemonItem)).map(i => ({
     display: i.displayName,
     type: 'Items',
     page: i.displayName,


### PR DESCRIPTION
Filters `PokemonItem` items from the search. The majority of people are searching for the pokemon itself and not the item, so it leads to clutter and confusion. And the shop/trade/whatever is linked from the pokemon page anyway.

Before:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/72aebabe-9305-4a60-9c98-c45afdc514b2)

After:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/6e0363d5-f37c-4140-a77e-934c4c8313cd)
