### PR TITLE
Simplify Mega Pokemon page

### DIFF
--- a/pages/Mega Pokémon/overview.html
+++ b/pages/Mega Pokémon/overview.html
@@ -11,11 +11,16 @@
         </thead>
         <tbody>
             <!-- ko foreach: pokemonList.filter(p => p.evolutions).flatMap(p => p.evolutions).filter(e => e.restrictions.find(r => r instanceof MegaEvolveRequirement)) -->
-            <tr data-bind="with: { basePokemon: PokemonHelper.getPokemonByName($data.basePokemon), megaPokemon: PokemonHelper.getPokemonByName($data.evolvedPokemon), info: megaInfo[$data.evolvedPokemon] }">
+            <tr data-bind="with: {
+                basePokemon: PokemonHelper.getPokemonByName($data.basePokemon),
+                megaPokemon: PokemonHelper.getPokemonByName($data.evolvedPokemon),
+                megaStone: GameConstants.humanifyString(GameConstants.MegaStoneType[$data.restrictions.find(r => r instanceof MegaEvolveRequirement).megaStone]),
+                obtainMethod: megaObtainMethods[$data.evolvedPokemon] ?? ''
+            }">
                 <td class="align-middle" data-bind="html: Wiki.md.renderInline(`[[Pokemon/${megaPokemon.name}]]`)"></td>
-                <td class="text-center align-middle" data-bind="text: $data.info?.megaStone || '-'"></td>
-                <td class="text-center align-middle" data-bind="text: ($data.basePokemon.attack * 500).toLocaleString()"></td>
-                <td class="align-middle" data-bind="html: Wiki.md.renderInline($data.info?.method ?? '') || '-'"></td>
+                <td class="text-center align-middle" data-bind="text: $data.megaStone"></td>
+                <td class="text-center align-middle" data-bind="text: ($data.basePokemon.attack * GameConstants.MEGA_REQUIRED_ATTACK_MULTIPLIER).toLocaleString()"></td>
+                <td class="align-middle" data-bind="html: Wiki.md.renderInline($data.obtainMethod) || '-'"></td>
             </tr>
             <!-- /ko -->
         </tbody>
@@ -23,186 +28,51 @@
 </div>
 
 <script type="text/javascript">
-const megaInfo = {
-    'Mega Beedrill': {
-        megaStone: 'Beedrillite',
-        method: `Battle [[Temporary Battles/Delta Giovanni]] in [[Towns/Sea Mauville]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Pidgeot': {
-        megaStone: 'Pidgeotite',
-        method: `Battle [[Temporary Battles/Mr. Stone]] in [[Towns/Rustboro City]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Blastoise': {
-        megaStone: 'Blastoisinite',
-        method: `Purchasable with 250,000 Water Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Squirtle]] was picked as the Kanto starter.`,
-    },
-    'Mega Charizard X': {
-        megaStone: 'Charizardite X',
-        method: `Purchasable with 125,000 Fire and Dragon Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]].`,
-    },
-    'Mega Charizard Y': {
-        megaStone: 'Charizardite Y',
-        method: `Purchasable with 125,000 Fire and Flying Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Charmander]] was picked as the Kanto starter.`,
-    },
-    'Mega Venusaur': {
-        megaStone: 'Venusaurite',
-        method: `Purchasable with 125,000 Grass and Poison Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Bulbasaur]] was picked as the Kanto starter.`,
-    },
-    'Mega Pinsir': {
-        megaStone: 'Pinsirite',
-        method: `Item drop in the [[Towns/Safari Zone]] after reaching Safari Level 10.`,
-    },
-    'Mega Scizor': {
-        megaStone: 'Scizorite',
-        method: `Item drop in the [[Towns/Friend Safari]] after reaching Safari Level 15.`,
-    },
-    'Mega Alakazam': {
-        megaStone: 'Alakazite',
-        method: `Trade for 1,000 Pink Shards in [[Towns/Laverre City]].`,
-    },
-    'Mega Blaziken': {
-        megaStone: 'Blazikenite',
-        method: `Purchasable with 125,000 Fire and Fighting Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Torchic]] was picked as the Hoenn starter.`,
-    },
-    'Mega Swampert': {
-        megaStone: 'Swampertite',
-        method: `Purchasable with 125,000 Water and Ground Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Mudkip]] was picked as the Hoenn starter.`,
-    },
-    'Mega Sceptile': {
-        megaStone: 'Sceptilite',
-        method: `Purchasable with 125,000 Grass and 125,000 Dragon Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Treecko]] was picked as the Hoenn starter.`,
-    },
-    'Mega Slowbro': {
-        megaStone: 'Slowbronite',
-        method: `Battle [[Temporary Battles/Shoal Fisherman]] in [[Dungeons/Shoal Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Gyarados': {
-        megaStone: 'Gyaradosite',
-        method: `Battle [[Temporary Battles/Team Flare Boss Lysandre 2]] in [[Towns/Couriway Town]] at Dusk after completing [[Quest Lines/A Beautiful World]].`,
-    },
-    'Mega Gengar': {
-        megaStone: 'Gengarite',
-        method: `Encounter 666 [[Pokemon/Gastly]], 444 [[Pokemon/Haunter]], and 13 [[Pokemon/Gengar]] then battle [[Temporary Battles/Hex Maniac Aster]] in [[Towns/Laverre City]].`,
-    },
-    'Mega Kangaskhan': {
-        megaStone: 'Kanghaskhanite',
-        method: `Legendary chest drop in [[Dungeons/Glittering Cave]].`,
-    },
-    'Mega Aerodactyl': {
-        megaStone: 'Aerodactylite',
-        method: `Found by digging in the [[Underground]].`,
-    },
-    'Mega Ampharos': {
-        megaStone: 'Ampharosite',
-        method: `Enter the code given by the Electric Trainer in [[Towns/Coumarine City]] (including the question mark) in the Start -> Save menu.`,
-    },
-    'Mega Steelix': {
-        megaStone: 'Steelixite',
-        method: `Battle [[Temporary Battles/Delta Brock]] in [[Dungeons/Granite Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Heracross': {
-        megaStone: 'Heracronite',
-        method: `Legendary chest drop in [[Dungeons/Santalune Forest]].`,
-    },
-    'Mega Houndoom': {
-        megaStone: 'Houndoominite',
-        method: `Battle [[Temporary Battles/Wild Houndour Horde]] near [[Routes/Kalos Route 16]], in Sunny [[Weather]]. Must have captured at least 500 [[Pokémon/Houndour]] and become Kalos Champion for the encounter to appear.`,
-    },
-    'Mega Tyranitar': {
-        megaStone: 'Tyranitarite',
-        method: `Clear [[Gyms/Cyllage City]]'s Gym 2000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
-    },
-    'Mega Gardevoir': {
-        megaStone: 'Gardevoirite',
-        method: `Battle [[Temporary Battles/Grand Duchess Diantha]] in [[Towns/Lumiose City]] after becoming Kalos Champion.`,
-    },
-    'Mega Sableye': {
-        megaStone: 'Sablenite',
-        method: `Found by digging in the [[Underground]].`,
-    },
-    'Mega Mawile': {
-        megaStone: 'Mawilite',
-        method: `Found by digging in the [[Underground]].`,
-    },
-    'Mega Aggron': {
-        megaStone: 'Aggronite',
-        method: `Clear [[Gyms/Cyllage City]]'s Gym 2,000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
-    },
-    'Mega Manectric': {
-        megaStone: 'Manectite',
-        method: `Battle [[Temporary Battles/Wild Electrike Horde]] near [[Routes/Kalos Route 16]], in Thunderstorm [[Weather]]. Must have captured at least 500 [[Pokémon/Electrike]] and become Kalos Champion for the encounter to appear.`,
-    },
-    'Mega Sharpedo': {
-        megaStone: 'Sharpedonite',
-        method: `Battle [[Temporary Battles/Delta Shelly]] in [[Dungeons/Aqua Hideout]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Camerupt': {
-        megaStone: 'Cameruptite',
-        method: `Battle [[Temporary Battles/Delta Tabitha]] in [[Dungeons/Magma Hideout]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Absol': {
-        megaStone: 'Absolite',
-        method: `Battle [[Temporary Battles/Calem 6]] in [[Towns/Kiloude City]] after becoming Kalos Champion.`,
-    },
-    'Mega Glalie': {
-        megaStone: 'Glalitite',
-        method: `Battle [[Temporary Battles/Icy Boulder]] in [[Dungeons/Shoal Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Salamence': {
-        megaStone: 'Salamencite',
-        method: `Battle [[Temporary Battles/Mega Draconid Elder]] in [[Dungeons/Meteor Falls]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Metagross': {
-        megaStone: 'Metagrossite',
-        method: `Battle [[Temporary Battles/Delta Steven]] in [[Towns/Pokémon League Hoenn]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Latias': {
-        megaStone: 'Latiasite',
-        method: `Battle [[Temporary Battles/Matt 3]] in [[Towns/Southern Island]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Latios': {
-        megaStone: 'Latiosite',
-        method: `Battle [[Temporary Battles/Courtney 3]] in [[Towns/Southern Island]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Rayquaza': {
-        megaStone: 'Meteorite',
-        method: `Progress in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Primal Kyogre': {
-        megaStone: 'Blue Orb',
-        method: `Progress in [[Quest Lines/Primal Reversion]].`,
-    },
-    'Primal Groudon': {
-        megaStone: 'Red Orb',
-        method: `Progress in [[Quest Lines/Primal Reversion]].`,
-    },
-    'Mega Lopunny': {
-        megaStone: 'Lopunnite',
-        method: `Clear stage 690 in [[Battle Frontier]].`,
-    },
-    'Mega Garchomp': {
-        megaStone: 'Garchompite',
-        method: `Legendary chest drop in [[Dungeons/Victory Road Kalos]].`,
-    },
-    'Mega Lucario': {
-        megaStone: 'Lucarionite',
-        method: `Defeat [[Temporary Battles/Korrina]] in [[Towns/Shalour City]].`,
-    },
-    'Mega Abomasnow': {
-        megaStone: 'Abomasite',
-        method: `Legendary chest drop in [[Dungeons/Frost Cavern]].`,
-    },
-    'Mega Gallade': {
-        megaStone: 'Galladite',
-        method: `Battle [[Temporary Battles/Dr Cozmo]] in [[Towns/Mossdeep Space Center]] after progressing in [[Quest Lines/The Delta Episode]].`,
-    },
-    'Mega Audino': {
-        megaStone: 'Audinite',
-        method: `Obtain [[Pokémon/Tornadus (Therian)]], [[Pokémon/Thundurus (Therian)]], and [[Pokémon/Landorus (Therian)]] from [[Dream Orbs]] then battle the [[Temporary Battles/DreamResearcher]] in [[Towns/Black and White Park]].`,
-    },
-    'Mega Diancie': {
-        megaStone: 'Diancite',
-        method: `Battle [[Temporary Battles/Rampaging Yveltal]] near [[Towns/Shalour City]], during [[Quest Lines/Princess Diancie]].`,
-    },
+const megaObtainMethods = {
+    'Mega Beedrill': `Battle [[Temporary Battles/Delta Giovanni]] in [[Towns/Sea Mauville]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Pidgeot': `Battle [[Temporary Battles/Mr. Stone]] in [[Towns/Rustboro City]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Blastoise': `Purchasable with 250,000 Water Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Squirtle]] was picked as the Kanto starter.`,
+    'Mega Charizard X': `Purchasable with 125,000 Fire and Dragon Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]].`,
+    'Mega Charizard Y': `Purchasable with 125,000 Fire and Flying Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Charmander]] was picked as the Kanto starter.`,
+    'Mega Venusaur': `Purchasable with 125,000 Grass and Poison Gems from the Stone Emporium in [[Towns/Lumiose City]] after battling [[Temporary Battles/Kalos Stone Salesman]] which becomes available after progressing in [[Quest Lines/A Beautiful World]]. Free if [[Pokémon/Bulbasaur]] was picked as the Kanto starter.`,
+    'Mega Pinsir': `Item drop in the [[Towns/Safari Zone]] after reaching Safari Level 10.`,
+    'Mega Scizor': `Item drop in the [[Towns/Friend Safari]] after reaching Safari Level 15.`,
+    'Mega Alakazam': `Trade for 1,000 Pink Shards in [[Towns/Laverre City]].`,
+    'Mega Blaziken': `Purchasable with 125,000 Fire and Fighting Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Torchic]] was picked as the Hoenn starter.`,
+    'Mega Swampert': `Purchasable with 125,000 Water and Ground Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Mudkip]] was picked as the Hoenn starter.`,
+    'Mega Sceptile': `Purchasable with 125,000 Grass and 125,000 Dragon Gems from the Gem Master in [[Towns/Fallarbor Town]] after battling [[Temporary Battles/Hoenn Stone Salesman]] which becomes available after progressing in [[Quest Lines/The Delta Episode]]. Free if [[Pokémon/Treecko]] was picked as the Hoenn starter.`,
+    'Mega Slowbro': `Battle [[Temporary Battles/Shoal Fisherman]] in [[Dungeons/Shoal Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Gyarados': `Battle [[Temporary Battles/Team Flare Boss Lysandre 2]] in [[Towns/Couriway Town]] at Dusk after completing [[Quest Lines/A Beautiful World]].`,
+    'Mega Gengar': `Encounter 666 [[Pokemon/Gastly]], 444 [[Pokemon/Haunter]], and 13 [[Pokemon/Gengar]] then battle [[Temporary Battles/Hex Maniac Aster]] in [[Towns/Laverre City]].`,
+    'Mega Kangaskhan': `Legendary chest drop in [[Dungeons/Glittering Cave]].`,
+    'Mega Aerodactyl': `Found by digging in the [[Underground]].`,
+    'Mega Ampharos': `Enter the code given by the Electric Trainer in [[Towns/Coumarine City]] (including the question mark) in the Start -> Save menu.`,
+    'Mega Steelix': `Battle [[Temporary Battles/Delta Brock]] in [[Dungeons/Granite Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Heracross': `Legendary chest drop in [[Dungeons/Santalune Forest]].`,
+    'Mega Houndoom': `Battle [[Temporary Battles/Wild Houndour Horde]] near [[Routes/Kalos Route 16]], in Sunny [[Weather]]. Must have captured at least 500 [[Pokémon/Houndour]] and become Kalos Champion for the encounter to appear.`,
+    'Mega Tyranitar': `Clear [[Gyms/Cyllage City]]'s Gym 2000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
+    'Mega Gardevoir': `Battle [[Temporary Battles/Grand Duchess Diantha]] in [[Towns/Lumiose City]] after becoming Kalos Champion.`,
+    'Mega Sableye': `Found by digging in the [[Underground]].`,
+    'Mega Mawile': `Found by digging in the [[Underground]].`,
+    'Mega Aggron': `Clear [[Gyms/Cyllage City]]'s Gym 2,000 or more times then battle [[Temporary Battles/Marquis Grant]] in [[Towns/Cyllage City]] after becoming Kalos Champion.`,
+    'Mega Manectric': `Battle [[Temporary Battles/Wild Electrike Horde]] near [[Routes/Kalos Route 16]], in Thunderstorm [[Weather]]. Must have captured at least 500 [[Pokémon/Electrike]] and become Kalos Champion for the encounter to appear.`,
+    'Mega Sharpedo': `Battle [[Temporary Battles/Delta Shelly]] in [[Dungeons/Aqua Hideout]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Camerupt': `Battle [[Temporary Battles/Delta Tabitha]] in [[Dungeons/Magma Hideout]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Absol': `Battle [[Temporary Battles/Calem 6]] in [[Towns/Kiloude City]] after becoming Kalos Champion.`,
+    'Mega Glalie': `Battle [[Temporary Battles/Icy Boulder]] in [[Dungeons/Shoal Cave]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Salamence': `Battle [[Temporary Battles/Mega Draconid Elder]] in [[Dungeons/Meteor Falls]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Metagross': `Battle [[Temporary Battles/Delta Steven]] in [[Towns/Pokémon League Hoenn]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Latias': `Battle [[Temporary Battles/Matt 3]] in [[Towns/Southern Island]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Latios': `Battle [[Temporary Battles/Courtney 3]] in [[Towns/Southern Island]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Rayquaza': `Progress in [[Quest Lines/The Delta Episode]].`,
+    'Primal Kyogre': `Progress in [[Quest Lines/Primal Reversion]].`,
+    'Primal Groudon': `Progress in [[Quest Lines/Primal Reversion]].`,
+    'Mega Lopunny': `Clear stage 690 in [[Battle Frontier]].`,
+    'Mega Garchomp': `Legendary chest drop in [[Dungeons/Victory Road Kalos]].`,
+    'Mega Lucario': `Defeat [[Temporary Battles/Korrina]] in [[Towns/Shalour City]].`,
+    'Mega Abomasnow': `Legendary chest drop in [[Dungeons/Frost Cavern]].`,
+    'Mega Gallade': `Battle [[Temporary Battles/Dr Cozmo]] in [[Towns/Mossdeep Space Center]] after progressing in [[Quest Lines/The Delta Episode]].`,
+    'Mega Audino': `Obtain [[Pokémon/Tornadus (Therian)]], [[Pokémon/Thundurus (Therian)]], and [[Pokémon/Landorus (Therian)]] from [[Dream Orbs]] then battle the [[Temporary Battles/DreamResearcher]] in [[Towns/Black and White Park]].`,
+    'Mega Diancie': `Battle [[Temporary Battles/Rampaging Yveltal]] near [[Towns/Shalour City]], during [[Quest Lines/Princess Diancie]].`,
 };
 </script>


### PR DESCRIPTION
Mega Stone names are in the game code now so we can automate that part instead of manually entering it along with the obtain method. Simplified the obtain method list after removing the mega stone name.