### PR TITLE
Allow datatable column sort to cycle back to default order

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77192,6 +77192,23 @@ const applyDatatables = () => {
                   }
                 }
             });
+
+            // Setup a custom handler to reset sort order after descending instead of going back to ascending
+            // Accomplished by finding and intercepting the mutation of the sorting th's class from desc to asc
+            const callback = (mutationList) => {
+                for (const mutation of mutationList) {
+                    if (mutation.type === "attributes" &&
+                        mutation.attributeName == "class" &&
+                        mutation.oldValue.includes("sorting_desc") &&
+                        mutation.target.classList.contains("sorting_asc")
+                    ) {
+                        $(`#${element.id}`).DataTable().order.neutral().draw();
+                    }
+                }
+            };
+            document.querySelectorAll('th.sorting').forEach((el) => {
+                new MutationObserver(callback).observe(el, { attributes: true, attributeFilter: ['class'], attributeOldValue: true });
+            });
         } catch(e){}
     });
 }

--- a/bundle.js
+++ b/bundle.js
@@ -77195,6 +77195,7 @@ const applyDatatables = () => {
 
             // Setup a custom handler to reset sort order after descending instead of going back to ascending
             // Accomplished by finding and intercepting the mutation of the sorting th's class from desc to asc
+            const tableId = element.id;
             const callback = (mutationList) => {
                 for (const mutation of mutationList) {
                     if (mutation.type === "attributes" &&
@@ -77202,11 +77203,11 @@ const applyDatatables = () => {
                         mutation.oldValue.includes("sorting_desc") &&
                         mutation.target.classList.contains("sorting_asc")
                     ) {
-                        $(`#${element.id}`).DataTable().order.neutral().draw();
+                        $(`#${tableId}`).DataTable().order.neutral().draw();
                     }
                 }
             };
-            document.querySelectorAll('th.sorting').forEach((el) => {
+            document.querySelectorAll(`#${tableId} th.sorting`).forEach((el) => {
                 new MutationObserver(callback).observe(el, { attributes: true, attributeFilter: ['class'], attributeOldValue: true });
             });
         } catch(e){}

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <!--Datatables-->
         <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.css"/>
         <script type="text/javascript" src="https://cdn.datatables.net/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.js"></script>
+        <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.6/api/order.neutral().min.js"></script>
 
         <!--Simple Markdown Editor-->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">

--- a/scripts/datatables.js
+++ b/scripts/datatables.js
@@ -42,6 +42,7 @@ const applyDatatables = () => {
 
             // Setup a custom handler to reset sort order after descending instead of going back to ascending
             // Accomplished by finding and intercepting the mutation of the sorting th's class from desc to asc
+            const tableId = element.id;
             const callback = (mutationList) => {
                 for (const mutation of mutationList) {
                     if (mutation.type === "attributes" &&
@@ -49,11 +50,11 @@ const applyDatatables = () => {
                         mutation.oldValue.includes("sorting_desc") &&
                         mutation.target.classList.contains("sorting_asc")
                     ) {
-                        $(`#${element.id}`).DataTable().order.neutral().draw();
+                        $(`#${tableId}`).DataTable().order.neutral().draw();
                     }
                 }
             };
-            document.querySelectorAll('th.sorting').forEach((el) => {
+            document.querySelectorAll(`#${tableId} th.sorting`).forEach((el) => {
                 new MutationObserver(callback).observe(el, { attributes: true, attributeFilter: ['class'], attributeOldValue: true });
             });
         } catch(e){}

--- a/scripts/datatables.js
+++ b/scripts/datatables.js
@@ -39,6 +39,23 @@ const applyDatatables = () => {
                   }
                 }
             });
+
+            // Setup a custom handler to reset sort order after descending instead of going back to ascending
+            // Accomplished by finding and intercepting the mutation of the sorting th's class from desc to asc
+            const callback = (mutationList) => {
+                for (const mutation of mutationList) {
+                    if (mutation.type === "attributes" &&
+                        mutation.attributeName == "class" &&
+                        mutation.oldValue.includes("sorting_desc") &&
+                        mutation.target.classList.contains("sorting_asc")
+                    ) {
+                        $(`#${element.id}`).DataTable().order.neutral().draw();
+                    }
+                }
+            };
+            document.querySelectorAll('th.sorting').forEach((el) => {
+                new MutationObserver(callback).observe(el, { attributes: true, attributeFilter: ['class'], attributeOldValue: true });
+            });
         } catch(e){}
     });
 }


### PR DESCRIPTION
Sort order now goes Default -> Asc -> Desc -> Default, rather than Default -> Asc -> Desc -> Asc -> Desc

There is a cleaner (code-wise) way of implementing this by injecting a button in to the DOM which calls `order.neutral()`, however I went with this approach as it's better UX (how people expect these sortable headers to work)