### PR TITLE
Fix gyms overview page

### DIFF
--- a/pages/Gyms/overview.html
+++ b/pages/Gyms/overview.html
@@ -16,7 +16,7 @@
         return (gymRegion <= GameConstants.MAX_AVAILABLE_REGION || gymRegion >= GameConstants.Region.final) && !g[0].includes('Trial')
     })">
         <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Gyms', $data[0]); return false; }">
-            <td class="align-middle" data-bind="text: $data[1].badgeReward"></td>
+            <td class="align-middle" data-bind="text: $index() + 1"></td>
             <td class="align-middle" data-bind="text: $data[1].leaderName.replace(/\d/g, '')"></td>
             <td class="align-middle" data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[($data[1].parent ?? TownList[$data[1].town])?.region] ?? '') || '-'"></td>
             <td class="align-middle" data-bind="text: $data[1].parent?.name ?? $data[1].town"></td>

--- a/pages/Gyms/overview.html
+++ b/pages/Gyms/overview.html
@@ -11,14 +11,17 @@
             <th>Requirements</th>
         </tr>
     </thead>
-    <tbody data-bind="foreach: Object.entries(GymList).filter((g) => GameConstants.getGymRegion(g[0]) <= GameConstants.MAX_AVAILABLE_REGION && !g[0].includes('Trial'))">
+    <tbody data-bind="foreach: Object.entries(GymList).filter((g) => {
+        const gymRegion = GameConstants.getGymRegion(g[0]);
+        return (gymRegion <= GameConstants.MAX_AVAILABLE_REGION || gymRegion >= GameConstants.Region.final) && !g[0].includes('Trial')
+    })">
         <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Gyms', $data[0]); return false; }">
             <td class="align-middle" data-bind="text: $data[1].badgeReward"></td>
             <td class="align-middle" data-bind="text: $data[1].leaderName.replace(/\d/g, '')"></td>
             <td class="align-middle" data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[($data[1].parent ?? TownList[$data[1].town])?.region] ?? '') || '-'"></td>
             <td class="align-middle" data-bind="text: $data[1].parent?.name ?? $data[1].town"></td>
             <td class="align-middle" data-bind="text: GameConstants.humanifyString(BadgeEnums[$data[1].badgeReward])"></td>
-            <td data-bind="html: $data[1].requirements.map(r => r.hint()).join('</br>')"></td>
+            <td class="align-middle" data-bind="html: $data[1].requirements.map(r => r.hint()).join('</br>')"></td>
         </tr>
     </tbody>
 </table>

--- a/pages/Gyms/overview.html
+++ b/pages/Gyms/overview.html
@@ -11,11 +11,11 @@
             <th>Requirements</th>
         </tr>
     </thead>
-    <tbody data-bind="foreach: Object.entries(GymList).filter((g) => !g[0].includes('Trial'))">
+    <tbody data-bind="foreach: Object.entries(GymList).filter((g) => GameConstants.getGymRegion(g[0]) <= GameConstants.MAX_AVAILABLE_REGION && !g[0].includes('Trial'))">
         <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Gyms', $data[0]); return false; }">
             <td class="align-middle" data-bind="text: $data[1].badgeReward"></td>
             <td class="align-middle" data-bind="text: $data[1].leaderName.replace(/\d/g, '')"></td>
-            <td class="align-middle" data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[($data[1].parent ?? TownList[$data[1].town]).region])"></td>
+            <td class="align-middle" data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[($data[1].parent ?? TownList[$data[1].town])?.region] ?? '') || '-'"></td>
             <td class="align-middle" data-bind="text: $data[1].parent?.name ?? $data[1].town"></td>
             <td class="align-middle" data-bind="text: GameConstants.humanifyString(BadgeEnums[$data[1].badgeReward])"></td>
             <td data-bind="html: $data[1].requirements.map(r => r.hint()).join('</br>')"></td>


### PR DESCRIPTION
Several Paldea gyms were added in the 10.14 game update causing issues on the gyms overview page. This fixes that and also changes it to only display gyms up to the current max available region. Future, unreleased gyms (Hisui and Paldea) will no longer display.

Also the order numbers were off in some places so changed it to use `$index() + 1` for the order number