### PR TITLE
Added Egg Steps to Routes / Gyms

### DIFF
--- a/pages/Battle Frontier/overview.html
+++ b/pages/Battle Frontier/overview.html
@@ -63,7 +63,7 @@
             </tr>
             <tr>
                 <td>Egg Steps per Pokémon</td>
-                <td data-bind="text: Math.round($data.stage() ** (1/2)).toLocaleString()"></td>  
+                <td data-bind="text: +Math.sqrt($data.stage()).toFixed(2)"></td>  
             </tr>
             <tr>
                 <td>Gems per Pokémon</td>

--- a/pages/Gyms/main.html
+++ b/pages/Gyms/main.html
@@ -38,10 +38,7 @@
                 </tr>
                 <tr>
                     <td>Egg Steps</td>
-                    <td data-bind="text: (() => {
-                        const norm = MapHelper.normalizeRoute($data.badgeReward * 3 + 1, GameConstants.Region.none);
-                        return +Math.sqrt(norm).toFixed(2);
-                    })()"></td>
+                    <td data-bind="text: +Math.sqrt(MapHelper.normalizeRoute($data.badgeReward * 3 + 1, GameConstants.Region.none)).toFixed(2)"></td>
                 </tr>
                 <!-- ko if: $data.requirements.length -->
                 <tr>

--- a/pages/Gyms/main.html
+++ b/pages/Gyms/main.html
@@ -36,6 +36,13 @@
                         <span data-bind="text: $data.moneyReward.toLocaleString()"></span>
                     </td>
                 </tr>
+                <tr>
+                    <td>Egg Steps</td>
+                    <td data-bind="text: (() => {
+                        const norm = MapHelper.normalizeRoute($data.badgeReward * 3 + 1, GameConstants.Region.none);
+                        return +Math.sqrt(norm).toFixed(2);
+                    })()"></td>
+                </tr>
                 <!-- ko if: $data.requirements.length -->
                 <tr>
                     <td class="text-center" colspan="2">Requirements</td>

--- a/pages/Routes/main.html
+++ b/pages/Routes/main.html
@@ -16,11 +16,7 @@
   </div>
   <div>
     <h3>Egg Steps:</h3>
-    <p data-bind="text: (() => {
-      const region = $data.region;
-      const norm = MapHelper.normalizeRoute($data?.number, region);
-      return +Math.sqrt(norm).toFixed(2);
-    })()"></p>
+    <p data-bind="text: +Math.sqrt(MapHelper.normalizeRoute($data?.number, $data.region)).toFixed(2)"></p>
   </div>
   <div>
     <h3>Roamer Chance:</h3>

--- a/pages/Routes/main.html
+++ b/pages/Routes/main.html
@@ -15,6 +15,14 @@
       <p data-bind="text: Math.round(PokemonFactory.routeHealth($data.number, $data.region)).toLocaleString()"></p>
   </div>
   <div>
+    <h3>Egg Steps:</h3>
+    <p data-bind="text: (() => {
+      const region = $data.region;
+      const norm = MapHelper.normalizeRoute($data?.number, region);
+      return +Math.sqrt(norm).toFixed(2);
+    })()"></p>
+  </div>
+  <div>
     <h3>Roamer Chance:</h3>
     <p data-bind="text: (() => {
       const region = $data.region;
@@ -23,7 +31,7 @@
       const roamingChance = ((max, min, maxRoute, minRoute) => Math.floor(max + ( (min - max) * (maxRoute - routeNum) / (maxRoute - minRoute))))(GameConstants.ROAMING_MAX_CHANCE, GameConstants.ROAMING_MIN_CHANCE, Math.max(...routes), Math.min(...routes));
       return '1/' + roamingChance.toLocaleString();
     })()"></p>
-</div>
+  </div>
   <div>
     <h3>Encounters</h3>
     <!-- ko foreach: Object.entries($data.pokemon) -->

--- a/pages/Routes/overview.html
+++ b/pages/Routes/overview.html
@@ -8,6 +8,7 @@
                 <th>Route Name</th>
                 <th>Encounters</th>
                 <th>Base HP</th>
+                <th>Egg Steps</th>
                 <th>Roamer Chance</th>
             </tr>
         </thead>
@@ -18,6 +19,11 @@
                 <td data-bind="text: $data.routeName, attr: { 'data-order': $index() }"></td>
                 <td data-bind="text: new Set(Object.values($data.pokemon).flat().map(p => typeof p != 'string' ? p.pokemon.flat() : p).flat()).size"></td>
                 <td data-bind="text: `❤️ ${Math.round(PokemonFactory.routeHealth($data.number, $data.region)).toLocaleString()}`, attr: { 'data-order': PokemonFactory.routeHealth($data.number, $data.region) }"></td>
+                <td data-bind="text: (() => {
+                    const region = $data.region;
+                    const norm = MapHelper.normalizeRoute($data?.number, region);
+                    return +Math.sqrt(norm).toFixed(2);
+                })()"></td>
                 <td data-bind="text: (() => {
                     const region = $data.region;
                     const routes = Routes.getRoutesByRegion($data.region).map(r => MapHelper.normalizeRoute(r.number, region));

--- a/pages/Routes/overview.html
+++ b/pages/Routes/overview.html
@@ -19,11 +19,7 @@
                 <td data-bind="text: $data.routeName, attr: { 'data-order': $index() }"></td>
                 <td data-bind="text: new Set(Object.values($data.pokemon).flat().map(p => typeof p != 'string' ? p.pokemon.flat() : p).flat()).size"></td>
                 <td data-bind="text: `❤️ ${Math.round(PokemonFactory.routeHealth($data.number, $data.region)).toLocaleString()}`, attr: { 'data-order': PokemonFactory.routeHealth($data.number, $data.region) }"></td>
-                <td data-bind="text: (() => {
-                    const region = $data.region;
-                    const norm = MapHelper.normalizeRoute($data?.number, region);
-                    return +Math.sqrt(norm).toFixed(2);
-                })()"></td>
+                <td data-bind="text: +Math.sqrt(MapHelper.normalizeRoute($data?.number, $data.region)).toFixed(2)"></td>
                 <td data-bind="text: (() => {
                     const region = $data.region;
                     const routes = Routes.getRoutesByRegion($data.region).map(r => MapHelper.normalizeRoute(r.number, region));


### PR DESCRIPTION
Added Egg Steps statistic to Routes page (both main and individual) and Gyms page (only individual since main looked bad).
Changed Battle Frontier Egg steps from rounded to fixed (2) to make it easier for the player to add the relevant multipliers for more accurate calculations, and also to keep it consistent with the other changes.