### PR TITLE
Shadow Pokemon

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -78558,13 +78558,54 @@ const hasLootWithRequirements = (dungeon) => {
 };
 hasLootWithRequirements.cache = new WeakMap();
 
+const getDungeonShadowPokemon = (dungeon) => {
+    // This will need to be updated to skip checking requirements once Orre XD is released
+    const shadows = [];
+    dungeon.enemyList.forEach(enemy => {
+        if (enemy instanceof DungeonTrainer) {
+            if (enemy.options?.requirement?.isCompleted() === false) {
+                return;
+            }
+            enemy.getTeam().forEach(pokemon => {
+                if (pokemon.shadow == GameConstants.ShadowStatus.Shadow) {
+                    shadows.push({
+                        pokemon: pokemon.name,
+                        dungeon: dungeon.name,
+                        trainer: enemy,
+                    });
+                }
+            });
+        }
+    });
+    dungeon.bossList.forEach(boss => {
+        if (boss instanceof DungeonTrainer) {
+            if (boss.options?.requirement?.isCompleted() === false) {
+                return;
+            }
+            boss.getTeam().forEach(pokemon => {
+                if (pokemon.shadow == GameConstants.ShadowStatus.Shadow) {
+                    shadows.push({
+                        pokemon: pokemon.name,
+                        dungeon: dungeon.name,
+                        trainer: boss,
+                        boss: true,
+                    });
+                }
+            });
+        }
+    });
+
+    return shadows;
+};
+
 module.exports = {
     getDungeonLoot,
     getDungeonLootChances,
     getDungeonLootChancesForItem,
     hasLootWithRequirements,
     getTableClearCounts,
-    itemTypeCategories
+    itemTypeCategories,
+    getDungeonShadowPokemon,
 };
 
 },{}],519:[function(require,module,exports){
@@ -79107,11 +79148,18 @@ const getBestVitamins = (baseAttack, eggCycles, region) => {
     return res;
 }
 
+const getAllAvailableShadowPokemon = () => {
+    return Object.values(dungeonList)
+        .filter(d => !TownList[d.name].requirements.some(req => req instanceof DevelopmentRequirement))
+        .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
+};
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
+    getAllAvailableShadowPokemon,
 }
 
 },{}],524:[function(require,module,exports){
@@ -79461,6 +79509,12 @@ const searchOptions = [
     type: 'Key Items',
     page: '',
   })),
+  // Shadow Pokemon
+  {
+    display: 'Shadow Pokémon',
+    type: 'Shadow Pokémon',
+    page: '',
+  },
 ];
 // Differentiate our different links with the same name
 searchOptions.forEach(a => {

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -68,10 +68,10 @@
             <!-- /ko -->
         </div>
         <br/>
-        <!-- ko if: $data.allAvailableShadowPokemon().length -->
+        <!-- ko if: Wiki.dungeons.getDungeonShadowPokemon($data).length -->
         <div>
             <h4>Shadow Pokémon</h4>
-            <!-- ko foreach: [...new Set($data.allAvailableShadowPokemon())] -->
+            <!-- ko foreach: [...new Set(Wiki.dungeons.getDungeonShadowPokemon($data).map(p => p.pokemon))] -->
             <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data).id + '.png'}"/>
             <a class="badge text-bg-secondary" href="#!" data-bind="text: $data, attr: { href: `#!Pokemon/${$data}` }"></a>
             <!-- /ko -->
@@ -81,7 +81,7 @@
         <div>
             <h3>Bosses</h3>
             <div class="table-responsive">
-                <table class="table table-bordered table-sm">
+                <table class="table table-bordered table-sm no-data-tables">
                     <thead>
                         <tr class="text-center">
                             <th>Pokémon / Trainer</th>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -56,7 +56,7 @@
         <!-- /ko -->
         <br/>
         <div>
-            <h3>Encounters:</h3>
+            <h3>Encounters</h3>
             <!-- ko foreach: $data.enemyList -->
                 <!-- ko ifnot: $data.name -->
                     <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == ($data.pokemon || $data)).id + '.png'}"/>
@@ -68,8 +68,18 @@
             <!-- /ko -->
         </div>
         <br/>
+        <!-- ko if: $data.allAvailableShadowPokemon().length -->
         <div>
-            <h3>Bosses:</h3>
+            <h4>Shadow Pokémon</h4>
+            <!-- ko foreach: [...new Set($data.allAvailableShadowPokemon())] -->
+            <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data).id + '.png'}"/>
+            <a class="badge text-bg-secondary" href="#!" data-bind="text: $data, attr: { href: `#!Pokemon/${$data}` }"></a>
+            <!-- /ko -->
+        </div>
+        <br/>
+        <!-- /ko -->
+        <div>
+            <h3>Bosses</h3>
             <div class="table-responsive">
                 <table class="table table-bordered table-sm">
                     <thead>
@@ -120,6 +130,9 @@
                                             <td class="align-middle text-center border-end border-bottom-0 w-50" style="border-color: var(--bs-table-border-color) !important;">
                                                 <img width="42px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == $data.name).id + '.png'}"/>
                                                 <a class="text-decoration-none" href="#!" data-bind="text: $data.name, attr: { href: `#!Pokemon/${$data.name}` }"></a>
+                                                <!-- ko if: $data.shadow >= GameConstants.ShadowStatus.Shadow -->
+                                                <img width="18px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>
+                                                <!-- /ko -->
                                             </td>
                                             <td class="align-middle text-center border-bottom-0 w-50" data-bind="text: $data.maxHealth.toLocaleString()"></td>
                                         </tr>
@@ -136,7 +149,7 @@
         </div>
         <br/>
         <div>
-            <h3>Possible Loot:</h3>
+            <h3>Possible Loot</h3>
             <!-- ko if: Wiki.dungeons.hasLootWithRequirements($data) -->
             <p>
                 This table assumes that all requirements are met, which isn't always possible.

--- a/pages/Shadow Pokémon/overview.html
+++ b/pages/Shadow Pokémon/overview.html
@@ -1,0 +1,31 @@
+<table class="table table-bordered table-striped table-hover">
+    <thead>
+        <tr>
+            <th>Pokémon</th>
+            <th>Dungeon</th>
+            <th>Trainer</th>
+            <th>Type </th>
+        </tr>
+    </thead>
+    <tbody data-bind="foreach: Wiki.pokemon.getAllAvailableShadowPokemon()">
+        <tr>
+            <td class="align-middle">
+                <img width="48px" class="me-1" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonMap[$data.pokemon].id + '.png'}"/>
+                <a href="#!" class="text-decoration-none" data-bind="text: $data.pokemon, attr: {href: `#!Pokemon/${$data.pokemon}` }"></a>
+            </td>
+            <td class="align-middle">
+                <a href="#!" class="text-decoration-none" data-bind="text: $data.dungeon, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
+            </td>
+            <td class="align-middle">
+                <!-- ko ifnot: $data.trainer.subTrainerClass -->
+                <img width="42px" class="me-1" data-bind="attr: {src: './pokeclicker/docs/assets/images/npcs/' + $data.trainer.trainerClass + '.png'}"/>
+                <!-- /ko -->
+                <!-- ko if: $data.trainer.subTrainerClass -->
+                <img width="42px" class="me-1" data-bind="attr: {src: './pokeclicker/docs/assets/images/npcs/' + $data.trainer.trainerClass + ' ' + $data.trainer.subTrainerClass + '.png'}"/>
+                <!-- /ko -->
+                <knockout data-bind="text: $data.trainer.name"></knockout>
+            </td>
+            <td class="align-middle" data-bind="text: $data.boss ? 'Boss' : 'Trainer'"></td>
+        </tr>
+    </tbody>
+</table>

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -314,11 +314,52 @@ const hasLootWithRequirements = (dungeon) => {
 };
 hasLootWithRequirements.cache = new WeakMap();
 
+const getDungeonShadowPokemon = (dungeon) => {
+    // This will need to be updated to skip checking requirements once Orre XD is released
+    const shadows = [];
+    dungeon.enemyList.forEach(enemy => {
+        if (enemy instanceof DungeonTrainer) {
+            if (enemy.options?.requirement?.isCompleted() === false) {
+                return;
+            }
+            enemy.getTeam().forEach(pokemon => {
+                if (pokemon.shadow == GameConstants.ShadowStatus.Shadow) {
+                    shadows.push({
+                        pokemon: pokemon.name,
+                        dungeon: dungeon.name,
+                        trainer: enemy,
+                    });
+                }
+            });
+        }
+    });
+    dungeon.bossList.forEach(boss => {
+        if (boss instanceof DungeonTrainer) {
+            if (boss.options?.requirement?.isCompleted() === false) {
+                return;
+            }
+            boss.getTeam().forEach(pokemon => {
+                if (pokemon.shadow == GameConstants.ShadowStatus.Shadow) {
+                    shadows.push({
+                        pokemon: pokemon.name,
+                        dungeon: dungeon.name,
+                        trainer: boss,
+                        boss: true,
+                    });
+                }
+            });
+        }
+    });
+
+    return shadows;
+};
+
 module.exports = {
     getDungeonLoot,
     getDungeonLootChances,
     getDungeonLootChancesForItem,
     hasLootWithRequirements,
     getTableClearCounts,
-    itemTypeCategories
+    itemTypeCategories,
+    getDungeonShadowPokemon,
 };

--- a/scripts/pages/pokemon.js
+++ b/scripts/pages/pokemon.js
@@ -50,9 +50,16 @@ const getBestVitamins = (baseAttack, eggCycles, region) => {
     return res;
 }
 
+const getAllAvailableShadowPokemon = () => {
+    return Object.values(dungeonList)
+        .filter(d => !TownList[d.name].requirements.some(req => req instanceof DevelopmentRequirement))
+        .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
+};
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
+    getAllAvailableShadowPokemon,
 }

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -292,6 +292,12 @@ const searchOptions = [
     type: 'Key Items',
     page: '',
   })),
+  // Shadow Pokemon
+  {
+    display: 'Shadow Pokémon',
+    type: 'Shadow Pokémon',
+    page: '',
+  },
 ];
 // Differentiate our different links with the same name
 searchOptions.forEach(a => {


### PR DESCRIPTION
Adds a Shadow Pokemon page listing all pokemon currently able to be obtained as shadows. Also updates the Dungeon page to list all shadow pokemon found in the dungeon and adds the shadow icon next to shadow pokemon that bosses have.

Someone can fill in info about shadow pokemon once this is merged.

shadow pokemon page:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/d113a85e-3670-49b7-aab6-4998af408278)

dungeon  page:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/e94b2c86-3d6f-42b4-a352-98212402ce5a)
