### PR TITLE
Add indication that a pokemon must be caught before it will appear in the safari zone

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -333,7 +333,14 @@
                         <div class="accordion-body" data-bind="foreach: Object.entries($data[PokemonLocationType.Safari])">
                             <h5 data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data[0]])"></h5>
                             <p data-bind="foreach: Object.entries($data[1])">
-                                <span class="badge text-bg-secondary" data-bind="text: `Chance ${$data[1]}%`"></span>
+                                <span class="badge text-bg-secondary" data-bind="with: { chance: $data[1], requireCaught: SafariPokemonList.list[$parent[0]]().find(p => p.name == Wiki.pageName())?.requireCaught }">
+                                    <knockout data-bind="text: `Chance ${$data.chance}%${$data.requireCaught ? ' 🔒' : ''}`, tooltip: {
+                                        title: $data.requireCaught ? `${Wiki.pageName()} will become available in the Safari Zone after being obtained elsewhere.` : '',
+                                        html: true,
+                                        placement: 'bottom',
+                                        trigger: 'hover'
+                                    }"></knockout>
+                                </span>
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
Adds a lock icon and tooltip to indicate that a pokemon must first be caught to appear in the safari zone.

![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/5eea650c-17eb-4786-986e-b2705fbac6ac)
