### PR TITLE
Added 'data-order' to certain pages

### DIFF
--- a/pages/Battle Frontier/overview.html
+++ b/pages/Battle Frontier/overview.html
@@ -11,7 +11,7 @@
         </thead>
         <tbody data-bind="foreach: BattleFrontierMilestones.milestoneRewards">
             <tr>
-                <td data-bind="text: $data.stage.toLocaleString()"></td>
+                <td data-bind="text: $data.stage.toLocaleString(), attr: { 'data-order': $data.stage }"></td>
                 <td>
                     <ko data-bind="text: $data.description"></ko>
                     <img data-bind="attr: { src: `./pokeclicker/docs/${$data.image}` }" width="28px"/>
@@ -20,7 +20,7 @@
                     BattleFrontierRunner.stage = ko.observable($data.stage);
                     BattleFrontierBattle.generateNewEnemy();
                     return BattleFrontierBattle.enemyPokemon.peek().health().toLocaleString();
-                  })()"></td>
+                  })(), attr: { 'data-order': $data.stage }"></td>
             </tr>
         </tbody>
     </table>

--- a/pages/Dungeons/overview.html
+++ b/pages/Dungeons/overview.html
@@ -42,13 +42,13 @@
         <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
             <tr data-bind="with: { region: GameConstants.camelCaseToString(GameConstants.Region[$data]), total: GameConstants.RegionDungeons[$data].map(d => dungeonList[d]).reduce((sum, d) => sum + d.tokenCost, 0) }">
                 <td data-bind="text: $data.region"></td>
-                <td><img src="./images/dungeonToken.svg" width="18px"/> 
+                <td data-bind="attr: { 'data-order': $data.total }"><img src="./images/dungeonToken.svg" width="18px"/> 
                     <ko data-bind="text: $data.total.toLocaleString()"></ko></td>
-                <td><img src="./images/dungeonToken.svg" width="18px"/> 
+                <td data-bind="attr: { 'data-order': $data.total }"><img src="./images/dungeonToken.svg" width="18px"/> 
                     <ko data-bind="text: ($data.total * 10).toLocaleString()"></ko></td>
-                <td><img src="./images/dungeonToken.svg" width="18px"/> 
+                <td data-bind="attr: { 'data-order': $data.total }"><img src="./images/dungeonToken.svg" width="18px"/> 
                     <ko data-bind="text: ($data.total * 100).toLocaleString()"></ko></td>
-                <td><img src="./images/dungeonToken.svg" width="18px"/> 
+                <td data-bind="attr: { 'data-order': $data.total }"><img src="./images/dungeonToken.svg" width="18px"/> 
                     <ko data-bind="text: ($data.total * 500).toLocaleString()"></ko></td>
             </tr>
         </tbody>

--- a/pages/Farm Hands/overview.html
+++ b/pages/Farm Hands/overview.html
@@ -17,7 +17,7 @@
                     <img data-bind="attr: { src: `./pokeclicker/docs/assets/images/profile/trainer-${$data.trainerSprite}.png` }"/>
                     <ko data-bind="text: $data.name"></ko>
                 </td>
-                <td class="text-nowrap">
+                <td class="text-nowrap" data-bind="attr: { 'data-order': $data.cost.amount }">
                     <img width="18px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/currency/${GameConstants.Currency[$data.cost.currency]}.svg` }"/>
                     <ko data-bind="text: $data.cost.amount.toLocaleString()"></ko>
                 </td>                

--- a/pages/Hatchery Helpers/overview.html
+++ b/pages/Hatchery Helpers/overview.html
@@ -16,7 +16,7 @@
                     <img data-bind="attr: { src: `./pokeclicker/docs/assets/images/profile/trainer-${$data.trainerSprite}.png` }"/>
                     <ko data-bind="text: $data.name"></ko>
                 </td>
-                <td class="text-nowrap">
+                <td class="text-nowrap" data-bind="attr: { 'data-order': $data.cost.amount }">
                     <img width="18px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/currency/${GameConstants.Currency[$data.cost.currency]}.svg` }"/>
                     <ko data-bind="text: $data.cost.amount.toLocaleString()"></ko>
                 </td>                
@@ -55,7 +55,7 @@
                         <img data-bind="attr: { src: `./pokeclicker/docs/assets/images/profile/trainer-${$data.trainerSprite}.png` }"/>
                         <ko data-bind="text: $data.name"></ko>
                     </td>
-                    <td class="text-nowrap">
+                    <td class="text-nowrap" data-bind="attr: { 'data-order': $data.cost.amount }">
                         <img width="18px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/currency/${GameConstants.Currency[$data.cost.currency]}.svg` }"/>
                         <ko data-bind="text: ($data.cost.amount * $parent.value ** 2 * 50).toLocaleString()"></ko>
                     </td>

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -125,7 +125,7 @@
                             <img width="40px" data-bind="attr: { src: `./pokeclicker/docs/assets/images/dungeons/chest-${$data.tier.toLowerCase()}.png`, title: `${$data.tier}` }"/>
                         </td>
                         <!-- ko foreach: $data.chances -->
-                        <td data-bind="text: typeof $data.chance === 'number' ? ($data.chance >= 0.0001 ? $data.chance.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }) : ('<' + 0.0001.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }))) : ($data.chance ?? '-')"></td>
+                        <td data-bind="text: typeof $data.chance === 'number' ? ($data.chance >= 0.0001 ? $data.chance.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }) : ('<' + 0.0001.toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2 }))) : ($data.chance ?? '-'), attr: { 'data-order': $data.chance }"></td>
                         <!-- /ko -->
                         <!-- ko if: itemChances.some((item) => item.requirement) -->
                         <td data-bind="text: $data.requirement ?? '-'"></td>

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -20,7 +20,7 @@
                     }"></span>
                 </td>
                 <td data-bind="text: $data.attack"></td>
-                <td data-bind="text: App.game.breeding.getSteps($data.eggCycles).toLocaleString()"></td>
+                <td data-bind="text: App.game.breeding.getSteps($data.eggCycles).toLocaleString(), attr: { 'data-order': $data.eggCycles }"></td>
                 <td data-bind="text: PokemonFactory.catchRateHelper($data.catchRate, true) + '%'"></td>
             </tr>
         </tbody>

--- a/pages/Vitamins/overview.html
+++ b/pages/Vitamins/overview.html
@@ -16,11 +16,11 @@
                         <a href="#" data-bind="text: $data, attr: { href: `#!Items/${$data}`}"></a>
                     </td>
                     <td data-bind="html: ItemList[$data].description"></td>
-                    <td>
+                    <td data-bind="attr: { 'data-order': ItemList[$data].basePrice }">
                         <img data-bind="attr: { src: `./images/${GameConstants.Currency[ItemList[$data].currency]}.svg` }" width="18px"/>
                         <ko data-bind="text: ItemList[$data].basePrice.toLocaleString()"></ko>
                     </td>
-                    <td>
+                    <td data-bind="attr: { 'data-order': ItemList[$data].basePrice }">
                         <img data-bind="attr: { src: `./images/${GameConstants.Currency[ItemList[$data].currency]}.svg` }" width="18px"/>
                         <ko data-bind="text: (ItemList[$data].basePrice * 100).toLocaleString()"></ko>
                     </td>


### PR DESCRIPTION
Some pages were sorting numbers wrongly in other language settings due to different decimal / thousand separators used so I added a 'data-order' attribute to certain problematic pages.