### PR TITLE
Fixed item links

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77045,7 +77045,7 @@ module.exports = function whichTypedArray(value) {
 },{"available-typed-arrays":1,"call-bind":6,"call-bind/callBound":5,"for-each":62,"gopd":66,"has-tostringtag/shams":70}],502:[function(require,module,exports){
 module.exports={
   "name": "pokeclicker",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "PokéClicker repository",
   "main": "index.js",
   "scripts": {
@@ -78979,11 +78979,13 @@ const getItemImage = (itemType, itemId) => {
     }
 };
 
+// TODO: rename
 const getItemPage = (itemType, itemId) => {
     const categoryAndPage = getItemCategoryAndPage(itemType, itemId);
     return `${categoryAndPage.category}/${categoryAndPage.page}`;
 };
 
+// TODO: rename
 const getItemCategoryAndPage = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
@@ -79012,13 +79014,34 @@ const getItemCategoryAndPage = (itemType, itemId) => {
                 page: '',
             };
     }
-}
+};
+
+const getItemPageFromObject = (item) => {
+    const categoryAndPage = getItemCategoryAndPageFromObject(item);
+    return `${categoryAndPage.category}/${categoryAndPage.page}`;
+};
+
+const getItemCategoryAndPageFromObject = (item) => {
+    if (item instanceof PokemonItem) {
+        return {
+            category: 'Pokémon',
+            page: item.type
+        };
+    } else {
+        return {
+            category: 'Items',
+            page: item.displayName
+        };
+    }
+};
 
 module.exports = {
     getItemName,
     getItemImage,
     getItemPage,
     getItemCategoryAndPage,
+    getItemPageFromObject,
+    getItemCategoryAndPageFromObject,
 };
 
 },{}],522:[function(require,module,exports){

--- a/bundle.js
+++ b/bundle.js
@@ -78979,14 +78979,12 @@ const getItemImage = (itemType, itemId) => {
     }
 };
 
-// TODO: rename
-const getItemPage = (itemType, itemId) => {
-    const categoryAndPage = getItemCategoryAndPage(itemType, itemId);
+const getItemPageFromTypeAndId = (itemType, itemId) => {
+    const categoryAndPage = getItemCategoryAndPageFromTypeAndId(itemType, itemId);
     return `${categoryAndPage.category}/${categoryAndPage.page}`;
 };
 
-// TODO: rename
-const getItemCategoryAndPage = (itemType, itemId) => {
+const getItemCategoryAndPageFromTypeAndId = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
             return {
@@ -79038,8 +79036,8 @@ const getItemCategoryAndPageFromObject = (item) => {
 module.exports = {
     getItemName,
     getItemImage,
-    getItemPage,
-    getItemCategoryAndPage,
+    getItemPageFromTypeAndId,
+    getItemCategoryAndPageFromTypeAndId,
     getItemPageFromObject,
     getItemCategoryAndPageFromObject,
 };

--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
         <script src="./pokeclicker/docs/libs/knockout-latest.js"></script>
 
         <!-- New module-based code from './modules' -->
-        <script src="./pokeclicker/docs/scripts/modules.min.js?v=0.10.14"></script>
+        <script src="./pokeclicker/docs/scripts/modules.min.js?v=0.10.15"></script>
 
         <!--Minified scripts-->
-        <script src="./pokeclicker/docs/scripts/script.min.js?v=0.10.14"></script>
+        <script src="./pokeclicker/docs/scripts/script.min.js?v=0.10.15"></script>
 
         <!--Bootstrap-->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -35,7 +35,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
         <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 
-        <link href="./styles.css?t=1692569909370" rel="stylesheet">
+        <link href="./styles.css?t=1693352970616" rel="stylesheet">
 
     </head>
     <body class="no-select">
@@ -247,6 +247,6 @@
         </template>
 
         <!-- Main wiki script -->
-        <script src="bundle.js?t=1692569909370"></script>
+        <script src="bundle.js?t=1693352970616"></script>
     </body>
 </html>

--- a/pages/Items/overview.html
+++ b/pages/Items/overview.html
@@ -9,6 +9,7 @@
         </thead>
         <tbody>
             <!-- ko foreach: Object.values(ItemList) -->
+            <!-- TODO: fix? (links still work, but PokemonItem pages are intentionally excluded from search - this should be changed too for consistency) -->
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Items', $data.displayName); return false; }">
                 <td data-bind="text: $data.displayName"></td>
                 <td data-bind="html: GameConstants.camelCaseToString($data.constructor.name)"></td>

--- a/pages/Items/overview.html
+++ b/pages/Items/overview.html
@@ -9,8 +9,7 @@
         </thead>
         <tbody>
             <!-- ko foreach: Object.values(ItemList) -->
-            <!-- TODO: fix? (links still work, but PokemonItem pages are intentionally excluded from search - this should be changed too for consistency) -->
-            <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Items', $data.displayName); return false; }">
+            <tr class="clickable" data-bind="click: () => { const page = Wiki.items.getItemCategoryAndPageFromObject($data); Wiki.gotoPage(page.category, page.page); return false; }">
                 <td data-bind="text: $data.displayName"></td>
                 <td data-bind="html: GameConstants.camelCaseToString($data.constructor.name)"></td>
                 <td data-bind="html: $data.description"></td>          

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -58,7 +58,7 @@
                         <td>Rare Hold Item</td>
                         <td>
                             <img style="height: 1.5em" data-bind="attr: { src: `./pokeclicker/docs/${Wiki.items.getItemImage($data.heldItem.type, $data.heldItem.id)}` }" class="item" />
-                            <a data-bind="text: Wiki.items.getItemName($data.heldItem.type, $data.heldItem.id), attr: { href: `#!${Wiki.items.getItemPage($data.heldItem.type, $data.heldItem.id)}` }"></a>
+                            <a data-bind="text: Wiki.items.getItemName($data.heldItem.type, $data.heldItem.id), attr: { href: `#!${Wiki.items.getItemPageFromTypeAndId($data.heldItem.type, $data.heldItem.id)}` }"></a>
                         </td>
                     </tr>
                 </tbody>

--- a/pages/Rare Hold Items/overview.html
+++ b/pages/Rare Hold Items/overview.html
@@ -9,7 +9,7 @@
         <tbody data-bind="foreach: pokemonList.filter(p => p.heldItem)">
             <tr>
                 <td class="clickable" data-bind="text: $data.name, click: () => { Wiki.gotoPage('Pokemon', $data.name); return false; }"></td>
-                <td class="clickable" data-bind="click: () => {const page = Wiki.items.getItemCategoryAndPage($data.heldItem.type, $data.heldItem.id); Wiki.gotoPage(page.category, page.page); return false; } ">
+                <td class="clickable" data-bind="click: () => {const page = Wiki.items.getItemCategoryAndPageFromTypeAndId($data.heldItem.type, $data.heldItem.id); Wiki.gotoPage(page.category, page.page); return false; } ">
                     <img style="height: 1.5em" data-bind="attr: { src: `./pokeclicker/docs/${Wiki.items.getItemImage($data.heldItem.type, $data.heldItem.id)}` }" class="item" />
                     <span data-bind="text: Wiki.items.getItemName($data.heldItem.type, $data.heldItem.id)"></span>
                 </td>

--- a/pages/Towns/main.html
+++ b/pages/Towns/main.html
@@ -64,7 +64,7 @@
                             <td class="align-middle">
                                 <img width="24" class="me-1" data-bind="attr: { src: './pokeclicker/docs/' + $data.image }" />
                                 <a href="#!" class="text-decoration-none" data-bind="text: $data.displayName,
-                                    attr: { href: `#!${$data instanceof PokemonItem ? 'Pokemon' : 'Items'}/${$data.displayName}` }"></a>
+                                    attr: { href: `#!${Wiki.items.getItemPageFromObject($data)}` }"></a>
                             </td>
                             <td class="align-middle">
                                 <img width="18" class="me-1" data-bind="attr: { src: `./images/${GameConstants.Currency[$data.currency]}.svg` }" />
@@ -91,7 +91,7 @@
                         <td class="align-middle">
                             <img width="24" class="me-1" data-bind="attr: { src: './pokeclicker/docs/' + $data.item.itemType.image }" />
                             <a href="#!" class="text-decoration-none" data-bind="text: $data.item.itemType.displayName,
-                                attr: { href: `#!${$data.item.itemType instanceof PokemonItem ? 'Pokemon' : 'Items'}/${$data.item.itemType.displayName}` }"></a>
+                                attr: { href: `#!${Wiki.items.getItemPageFromObject($data.item.itemType)}` }"></a>
                         </td>
                         <td>
                             <!-- ko foreach: $data.shards -->
@@ -125,7 +125,7 @@
                         <td class="align-middle">
                             <img width="24" class="me-1" data-bind="attr: { src: './pokeclicker/docs/' + $data.item.itemType.image }" />
                             <a href="#!" class="text-decoration-none" data-bind="text: $data.item.itemType.displayName,
-                                attr: { href: `#!${$data.item.itemType instanceof PokemonItem ? 'Pokemon' : 'Items'}/${$data.item.itemType.displayName}` }"></a>
+                                attr: { href: `#!${Wiki.items.getItemPageFromObject($data.item.itemType)}` }"></a>
                         </td>
                         <td data-bind="foreach: $data.gems">
                             <div>

--- a/scripts/pages/items.js
+++ b/scripts/pages/items.js
@@ -28,11 +28,13 @@ const getItemImage = (itemType, itemId) => {
     }
 };
 
+// TODO: rename
 const getItemPage = (itemType, itemId) => {
     const categoryAndPage = getItemCategoryAndPage(itemType, itemId);
     return `${categoryAndPage.category}/${categoryAndPage.page}`;
 };
 
+// TODO: rename
 const getItemCategoryAndPage = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
@@ -61,11 +63,32 @@ const getItemCategoryAndPage = (itemType, itemId) => {
                 page: '',
             };
     }
-}
+};
+
+const getItemPageFromObject = (item) => {
+    const categoryAndPage = getItemCategoryAndPageFromObject(item);
+    return `${categoryAndPage.category}/${categoryAndPage.page}`;
+};
+
+const getItemCategoryAndPageFromObject = (item) => {
+    if (item instanceof PokemonItem) {
+        return {
+            category: 'Pokémon',
+            page: item.type
+        };
+    } else {
+        return {
+            category: 'Items',
+            page: item.displayName
+        };
+    }
+};
 
 module.exports = {
     getItemName,
     getItemImage,
     getItemPage,
     getItemCategoryAndPage,
+    getItemPageFromObject,
+    getItemCategoryAndPageFromObject,
 };

--- a/scripts/pages/items.js
+++ b/scripts/pages/items.js
@@ -28,14 +28,12 @@ const getItemImage = (itemType, itemId) => {
     }
 };
 
-// TODO: rename
-const getItemPage = (itemType, itemId) => {
-    const categoryAndPage = getItemCategoryAndPage(itemType, itemId);
+const getItemPageFromTypeAndId = (itemType, itemId) => {
+    const categoryAndPage = getItemCategoryAndPageFromTypeAndId(itemType, itemId);
     return `${categoryAndPage.category}/${categoryAndPage.page}`;
 };
 
-// TODO: rename
-const getItemCategoryAndPage = (itemType, itemId) => {
+const getItemCategoryAndPageFromTypeAndId = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
             return {
@@ -87,8 +85,8 @@ const getItemCategoryAndPageFromObject = (item) => {
 module.exports = {
     getItemName,
     getItemImage,
-    getItemPage,
-    getItemCategoryAndPage,
+    getItemPageFromTypeAndId,
+    getItemCategoryAndPageFromTypeAndId,
     getItemPageFromObject,
     getItemCategoryAndPageFromObject,
 };


### PR DESCRIPTION
This PR aims to unify link creation for item pages. The `displayName` property doesn't always refer to the actual name of the item. In fact, in the case of `PokemonItem` instances, it is the localized name of the Pokémon.

This PR fixes:
- Localized Pokémon names resulting in incorrect links (as seen in Discord)
- Pokémon Item display names resulting in incorrect links (Example: `Towns/Fish Shop` linking to `Pokémon/Probably Feebas`)

This PR does NOT change the way item names are displayed to the user. Localized names would still be localized, although wiki localization is not intended to be available yet.

`Item` instances are passed into `Wiki.items.getItemPageFromObject` or `Wiki.items.getItemCategoryAndPageFromObject` to obtain either a page link or an object containing the category and the page.