### PR TITLE
Dream orb loot links

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -78231,7 +78231,8 @@ const getOrbLoot = (orb) => {
     return {
       name: item.item.id,
       image: item.item.type === ItemType.underground ? UndergroundItems.getByName(item.item.id)?.image : ItemList[item.item.id]?.image,
-      itemType: ItemType[item.item.type],
+      itemType: item.item.type,
+      itemTypeAsString: ItemType[item.item.type],
       chance: item.weight / weightSum,
     }
   });
@@ -78987,10 +78988,8 @@ const getItemPageFromTypeAndId = (itemType, itemId) => {
 const getItemCategoryAndPageFromTypeAndId = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
-            return {
-                category: 'Items',
-                page: ItemList[itemId].displayName,
-            };
+            const item = ItemList[itemId];
+            return getItemCategoryAndPageFromObject(item);
         case ItemType.underground:
             return {
                 category: 'Items',

--- a/pages/Dream Orbs/overview.html
+++ b/pages/Dream Orbs/overview.html
@@ -11,14 +11,14 @@
         </thead>
         <tbody>
             <!-- ko foreach: Wiki.dreamOrbs.getOrbLoot($data) -->
-            <tr class="text-nowrap clickable" data-bind="click: () => { Wiki.gotoPage('Items', $data.name); return false; }">
+            <tr class="text-nowrap clickable" data-bind="click: () => { const page = Wiki.items.getItemCategoryAndPageFromTypeAndId($data.itemType, $data.name); Wiki.gotoPage(page.category, page.page); return false; }">
                 <td>
                     <!-- ko if: $data.image -->
                     <img class="table-image" data-bind="attr: { src: `./pokeclicker/docs/${$data.image}`, alt: `Icon of item ${$data.name}` }"/>
                     <!-- /ko -->
                     <ko data-bind="text: $data.name"></ko>
                 </td>
-                <td data-bind="text: $data.itemType"></td>
+                <td data-bind="text: $data.itemTypeAsString"></td>
                 <td data-bind="text: `${($data.chance * 100).toLocaleString()}%`"></td>
             </tr>
             <!-- /ko -->

--- a/scripts/pages/dreamOrbs.js
+++ b/scripts/pages/dreamOrbs.js
@@ -4,7 +4,8 @@ const getOrbLoot = (orb) => {
     return {
       name: item.item.id,
       image: item.item.type === ItemType.underground ? UndergroundItems.getByName(item.item.id)?.image : ItemList[item.item.id]?.image,
-      itemType: ItemType[item.item.type],
+      itemType: item.item.type,
+      itemTypeAsString: ItemType[item.item.type],
       chance: item.weight / weightSum,
     }
   });

--- a/scripts/pages/items.js
+++ b/scripts/pages/items.js
@@ -36,10 +36,8 @@ const getItemPageFromTypeAndId = (itemType, itemId) => {
 const getItemCategoryAndPageFromTypeAndId = (itemType, itemId) => {
     switch (itemType) {
         case ItemType.item:
-            return {
-                category: 'Items',
-                page: ItemList[itemId].displayName,
-            };
+            const item = ItemList[itemId];
+            return getItemCategoryAndPageFromObject(item);
         case ItemType.underground:
             return {
                 category: 'Items',


### PR DESCRIPTION
Changed dream orb loot to use the same function for links as the other item-related pages. (See #134)
This means that Pokémon will now link to the Pokémon's page instead of the "Pokemon Item".
The displayed values are unaffected. The dream orb page never showed the display name in the first place, only the internal name of the PokemonItem is used.