### PR TITLE
Show Pokémon shiny version on mouseover

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -27,6 +27,7 @@
                 <tbody>
                     <tr>
                         <td class="text-center" colspan="2">
+                            <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
                             <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '.png'}"/>
                         </td>
                     </tr>

--- a/styles.css
+++ b/styles.css
@@ -340,3 +340,12 @@ td.tight {
 .Freeze_Mulch {
   filter: brightness(200%) hue-rotate(210deg);
 }
+
+.mouseover-reveal {
+  position: absolute;
+  opacity: 0;
+}
+
+.mouseover-reveal:hover {
+  opacity: 1;
+}


### PR DESCRIPTION
Super simple change. Someone asked about whether Pinkan Pokemon had shiny versions... that should be available to see on the wiki:

Normal:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/2b33b440-410a-41f8-ab4d-1fe76266f159)

Mouseover for shiny:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/280ee39f-979b-4942-ba16-72fa81634fdd)