### PR TITLE
Main Page Restructuring

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -1,35 +1,55 @@
+<center><h4>Maps & Navigation</h4></center>
 <div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
-    <a href="#!Pokemon" class="btn btn-primary text-nowrap">Pokémon</a>
-    <a href="#!Items" class="btn btn-primary text-nowrap">Items</a>
-    <a href="#!Towns" class="btn btn-primary text-nowrap">Towns</a>
-    <a href="#!Gyms" class="btn btn-primary text-nowrap">Gyms</a>
-    <a href="#!Dungeons" class="btn btn-primary text-nowrap">Dungeons</a>
-    <a href="#!Routes" class="btn btn-primary text-nowrap">Routes</a>
-    <a href="#!Gems" class="btn btn-primary text-nowrap">Gems</a>
-    <a href="#!Berries" class="btn btn-primary text-nowrap">Berries</a>
-    <a href="#!Battle_Cafe" class="btn btn-primary text-nowrap">Battle Café</a>
-    <a href="#!Battle_Frontier" class="btn btn-primary text-nowrap">Battle Frontier</a>
-    <a href="#!Eggs" class="btn btn-primary text-nowrap">Eggs</a>
-    <a href="#!Quest_Lines" class="btn btn-primary text-nowrap">Quest Lines</a>
-    <a href="#!Vitamins" class="btn btn-primary text-nowrap">Vitamins</a>
-    <a href="#!Farm" class="btn btn-primary text-nowrap">Farm</a>
-    <a href="#!Farm_Simulator" class="btn btn-primary text-nowrap">Farm Simulator</a>
-    <a href="#!Farm_Hands" class="btn btn-primary text-nowrap">Farm Hands</a>
-    <a href="#!Hatchery" class="btn btn-primary text-nowrap">Hatchery</a>
-    <a href="#!Hatchery_Helpers" class="btn btn-primary text-nowrap">Hatchery Helpers</a>
-    <a href="#!Oak_Items" class="btn btn-primary text-nowrap">Oak Items</a>
+    <a href="#!Regions" class="btn btn-primary text-nowrap">Regions</a></td>
+    <a href="#!Towns" class="btn btn-primary text-nowrap">Towns</a></td>
+    <a href="#!Routes" class="btn btn-primary text-nowrap">Routes</a></td>
+    <a href="#!Gyms" class="btn btn-primary text-nowrap">Gyms</a></td>
+    <a href="#!Dungeons" class="btn btn-primary text-nowrap">Dungeons</a></td>
+    <a href="#!Temporary_Battles" class="btn btn-primary text-nowrap">Temporary Battles</a></td>
+    <a href="#!Safari" class="btn btn-primary text-nowrap">Safari</a></td>
+    <a href="#!Battle_Cafe" class="btn btn-primary text-nowrap">Battle Café</a></td>
+    <a href="#!Battle_Frontier" class="btn btn-primary text-nowrap">Battle Frontier</a></td>
+    <a href="#!Farm" class="btn btn-primary text-nowrap">Farm</a></td>
+    <a href="#!Hatchery" class="btn btn-primary text-nowrap">Hatchery</a></td>
+</div>
+<br>
+<center><h4>Items</h4></center>
+<div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
     <a href="#!Key_Items" class="btn btn-primary text-nowrap">Key Items</a>
-    <a href="#!Weather" class="btn btn-primary text-nowrap">Weather</a>
-    <a href="#!Daily_Deals" class="btn btn-primary text-nowrap">Daily Deals</a>
-    <a href="#!Temporary_Battles" class="btn btn-primary text-nowrap">Temporary Battles</a>
-    <a href="#!Events" class="btn btn-primary text-nowrap">Events</a>
+    <a href="#!Oak_Items" class="btn btn-primary text-nowrap">Oak Items</a>
+    <a href="#!Items" class="btn btn-primary text-nowrap">Items</a>
+    <a href="#!Berries" class="btn btn-primary text-nowrap">Berries</a>
+    <a href="#!Eggs" class="btn btn-primary text-nowrap">Eggs</a>
+
+</div>
+<br>
+<center><h4>Currencies</h4></center>
+<div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
     <a href="#!Pokémon_Dollars" class="btn btn-primary text-nowrap">Pokémon Dollars</a>
     <a href="#!Dungeon_Tokens" class="btn btn-primary text-nowrap">Dungeon Tokens</a>
     <a href="#!Quest_Points" class="btn btn-primary text-nowrap">Quest Points</a>
     <a href="#!Farm_Points" class="btn btn-primary text-nowrap">Farm Points</a>
     <a href="#!Diamonds" class="btn btn-primary text-nowrap">Diamonds</a>
     <a href="#!Battle_Points" class="btn btn-primary text-nowrap">Battle Points</a>
+
 </div>
+<br>
+<center><h4>Pokemon and Mechanics</h4></center>
 <div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
+    <a href="#!Pokemon" class="btn btn-primary text-nowrap">Pokémon</a>
+    <a href="#!Gems" class="btn btn-primary text-nowrap">Gems</a>
+    <a href="#!Quest_Lines" class="btn btn-primary text-nowrap">Quest Lines</a>
+    <a href="#!Farm_Hands" class="btn btn-primary text-nowrap">Farm Hands</a>
+    <a href="#!Hatchery_Helpers" class="btn btn-primary text-nowrap">Hatchery Helpers</a>
+    <a href="#!Weather" class="btn btn-primary text-nowrap">Weather</a>
+    <a href="#!Events" class="btn btn-primary text-nowrap">Events</a>
+
+</div>
+<br>
+<center><h4>Guides, Calculators, Statistics, and Miscellaneous Information</h4></center>
+<div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
+    <a href="#!Daily_Deals" class="btn btn-primary text-nowrap">Daily Deals</a>
+    <a href="#!Farm_Simulator" class="btn btn-primary text-nowrap">Farm Simulator</a>
+    <a href="#!Vitamins" class="btn btn-primary text-nowrap">Vitamins</a>
     <a href="#!Wiki_Guide" class="btn btn-primary text-nowrap">Wiki Guide</a>
 </div>


### PR DESCRIPTION
Re-ordering the main page to have categories like the old wiki. Looks better than just a blob of links

![chrome_WqHoiKgCIB](https://github.com/pokeclicker/pokeclicker-wiki/assets/24837595/1faed0af-1b26-46e4-a08d-62b1e4ee82cc)
