### PR TITLE
Show subregion map with location highlighted for towns/dungeons/routes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77617,8 +77617,10 @@ const getRegionMap = (region, subregion) => {
 }
 
 let cachedPokeclickerHTML;
+let overlaySVG = ko.observable("");
 
 const fetchPokeclickerHTML = (mapLocationSelector) => {
+    overlaySVG("");
     if (!cachedPokeclickerHTML) {
         $.get('/pokeclicker/docs/index.html',
             function(data) {
@@ -77631,14 +77633,16 @@ const fetchPokeclickerHTML = (mapLocationSelector) => {
     }
 }
 
-const getLocationOverlaySVG = (town) => {
+const getLocationOverlaySVG = (town, region, subregion) => {
+    // Replace single quotes with their escaped versions
+    town = town.replaceAll(String.raw`'`, String.raw`\\'`)
     fetchPokeclickerHTML(`'${town}'`);
-    return true;
+    return getRegionMap(region, subregion);
 }
 
-const getRouteOverlaySVG = (route, region) => {
+const getRouteOverlaySVG = (route, region, subregion) => {
     fetchPokeclickerHTML(`moveToRoute(${route}, ${region})`);
-    return true;
+    return getRegionMap(region, subregion);
 }
 
 const setMapLocation = (selector) => {
@@ -77662,14 +77666,12 @@ const setMapLocation = (selector) => {
         const parent = firstTownNode.parentNode;
         parent.replaceChildren(...outputElements);
         map.replaceChildren(parent);
-        // Weird hack because sometimes manually created SVG elements don't render until they are messed with
-        map.innerHTML = map.innerHTML + "";
         // Scrub all the knockout bindings so they don't affect the rendering
         const allElements = map.querySelectorAll("*");
         allElements.forEach(element => {
             element.removeAttribute('data-bind');
         });
-        $('#map-overlay').html(map);
+        overlaySVG(map.outerHTML);
     }
 }
 
@@ -77677,9 +77679,9 @@ module.exports = {
     requirementHints,
     getEvolutionHints,
     getRegionName,
-    getRegionMap,
     getLocationOverlaySVG,
     getRouteOverlaySVG,
+    overlaySVG,
 }
 
 },{}],508:[function(require,module,exports){

--- a/bundle.js
+++ b/bundle.js
@@ -77666,10 +77666,13 @@ const setMapLocation = (selector) => {
         const parent = firstTownNode.parentNode;
         parent.replaceChildren(...outputElements);
         map.replaceChildren(parent);
-        // Scrub all the knockout bindings so they don't affect the rendering
         const allElements = map.querySelectorAll("*");
         allElements.forEach(element => {
+            // Scrub all the knockout bindings so they don't affect the rendering
             element.removeAttribute('data-bind');
+            // And all image hrefs
+            element.removeAttribute('href');
+            element.removeAttribute('xlink:href');
         });
         overlaySVG(map.outerHTML);
     }

--- a/bundle.js
+++ b/bundle.js
@@ -77599,10 +77599,87 @@ const getRegionName = (region) => {
     return GameConstants.camelCaseToString(GameConstants.Region[region]);
 };
 
+const getRegionMap = (region, subregion) => {
+    // There might be a way to grab these out of the HTML
+    const regionPNGs = [
+        ['kanto-kanto', 'kanto-sevii123', 'kanto-sevii4567' ],
+        ['johto'],
+        ['hoenn', 'orre'],
+        ['sinnoh'],
+        ['unova'],
+        ['kalos'],
+        ['alola-melemele', 'alola-akala', 'alola-ulaula', 'alola-poni', 'alola-magikarp-jump'],
+        ['galar-south', 'galar-north', 'galar-isle-of-armor', 'galar-crown-tundra'],
+        [], // hisui
+        [], // paldea
+    ];
+    return regionPNGs[region][subregion];
+}
+
+let cachedPokeclickerHTML;
+
+const fetchPokeclickerHTML = (mapLocationSelector) => {
+    if (!cachedPokeclickerHTML) {
+        $.get('/pokeclicker/docs/index.html',
+            function(data) {
+                cachedPokeclickerHTML = data;
+                setMapLocation(mapLocationSelector);
+            }
+        );
+    } else {
+        setMapLocation(mapLocationSelector);
+    }
+}
+
+const getLocationOverlaySVG = (town) => {
+    fetchPokeclickerHTML(`'${town}'`);
+    return true;
+}
+
+const getRouteOverlaySVG = (route, region) => {
+    fetchPokeclickerHTML(`moveToRoute(${route}, ${region})`);
+    return true;
+}
+
+const setMapLocation = (selector) => {
+    const dom = new DOMParser().parseFromString(cachedPokeclickerHTML, 'text/html');
+    const map = dom.querySelector('#map');
+
+    const locationElements = map.querySelectorAll(`[data-bind*="${selector}"]`);
+    if (locationElements.length > 0) {
+        const outputElements = [];
+        const firstTownNode = locationElements[0];
+
+        if (locationElements.length == 1 && firstTownNode.nodeName === "image") {
+            // If there is only one element and it's an image (due to being a dungeon-in-a-town), replace image with rect that we can fill
+            const newNode = document.createElement("rect");
+            [...firstTownNode.attributes].forEach(attr => newNode.setAttribute(attr.nodeName, attr.nodeValue));
+            outputElements.push(newNode);
+        } else {
+            outputElements.push(...locationElements);
+        }
+        // Create our own map mini-DOM with only the necessary elements
+        const parent = firstTownNode.parentNode;
+        parent.replaceChildren(...outputElements);
+        map.replaceChildren(parent);
+        // Weird hack because sometimes manually created SVG elements don't render until they are messed with
+        map.innerHTML = map.innerHTML + "";
+        // Scrub all the knockout bindings so they don't affect the rendering
+        const allElements = map.querySelectorAll("*");
+        allElements.forEach(element => {
+            element.removeAttribute('data-bind');
+        });
+        $('#map-overlay').html(map);
+    }
+}
+
 module.exports = {
     requirementHints,
     getEvolutionHints,
     getRegionName,
+    getRegionMap,
+    getLocationOverlaySVG,
+    getRouteOverlaySVG,
 }
 
 },{}],508:[function(require,module,exports){

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -14,16 +14,18 @@
                         </td>
                     </tr>
                     <!-- ko with: Object.values(TownList).find(town => town.dungeon === $data) -->
-                    <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)">
-                        <td colspan="2">
-                            <div id="map-container">
-                                <div id="map-overlay" data-bind="if: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName())"></div>
-                                <img class="w-100" width="1600" data-bind="attr: {
-                                    src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)}.png?v=0.10.16`
-                                }" />
-                            </div>
-                        </td>
-                    </tr>
+                        <!-- ko with: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName(), $data.region, $data.subRegion), as: 'filePath' -->
+                        <tr data-bind="with: Wiki.gameHelper.overlaySVG(), as: 'overlaySVG'">
+                            <td colspan="2">
+                                <div id="map-container">
+                                    <div id="map-overlay" data-bind="html: overlaySVG"></div>
+                                    <img class="w-100" width="1600" data-bind="attr: {
+                                        src:`images/${filePath}.png`
+                                    }" />
+                                </div>
+                            </td>
+                        </tr>
+                        <!-- /ko -->
                     <tr>
                         <td>Region</td>
                         <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></td>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -1,6 +1,6 @@
 <div>
     <!-- ko with: dungeonList[Wiki.pageName()] -->
-        <div class="float-lg-end col-lg-3 m-2">
+        <div class="float-lg-end col-lg-4 m-2">
             <table class="table table-striped table-bordered">
                 <thead>
                     <tr>
@@ -14,6 +14,16 @@
                         </td>
                     </tr>
                     <!-- ko with: Object.values(TownList).find(town => town.dungeon === $data) -->
+                    <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)">
+                        <td colspan="2">
+                            <div id="map-container">
+                                <div id="map-overlay" data-bind="if: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName())"></div>
+                                <img class="w-100" width="1600" data-bind="attr: {
+                                    src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)}.png?v=0.10.16`
+                                }" />
+                            </div>
+                        </td>
+                    </tr>
                     <tr>
                         <td>Region</td>
                         <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></td>

--- a/pages/Routes/main.html
+++ b/pages/Routes/main.html
@@ -2,13 +2,34 @@
 <h2>Route not found...</h2>
 <!-- /ko -->
 <div data-bind="with: Routes.regionRoutes.find(r => r.routeName == Wiki.pageName())">
-  <div>
-    <h3>Region</h3>
-    <p data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></p>
-  </div>
-  <div>
-    <h3>Sub Region</h3>
-    <p data-bind="text: SubRegions.list[$data.region][$data.subRegion ?? 0].name"></p>
+  <div class="float-lg-end col-lg-4 m-2">
+    <table class="table table-hover table-striped table-bordered">
+      <thead>
+        <tr>
+          <th class="text-center" colspan="2" data-bind="text: Wiki.pageName()"></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion ?? 0)">
+          <td colspan="2">
+            <div id="map-container">
+              <div id="map-overlay" data-bind="if: Wiki.gameHelper.getRouteOverlaySVG($data.number, $data.region)"></div>
+              <img class="w-100" width="1600" data-bind="attr: {
+                src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion ?? 0)}.png?v=0.10.16`
+              }" />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>Region</td>
+          <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></td>
+        </tr>
+        <tr>
+          <td>Sub Region</td>
+          <td data-bind="text: SubRegions.list[$data.region][$data.subRegion ?? 0].name"></td>
+        </tr>
+      </tbody>
+    </table>
   </div>
   <div>
       <h3>Base HP:</h3>

--- a/pages/Routes/main.html
+++ b/pages/Routes/main.html
@@ -10,16 +10,18 @@
         </tr>
       </thead>
       <tbody>
-        <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion ?? 0)">
+        <!-- ko with: Wiki.gameHelper.getRouteOverlaySVG($data.number, $data.region, $data.subRegion ?? 0), as: 'filePath' -->
+        <tr data-bind="with: Wiki.gameHelper.overlaySVG(), as: 'overlaySVG'">
           <td colspan="2">
             <div id="map-container">
-              <div id="map-overlay" data-bind="if: Wiki.gameHelper.getRouteOverlaySVG($data.number, $data.region)"></div>
+              <div id="map-overlay" data-bind="html: overlaySVG"></div>
               <img class="w-100" width="1600" data-bind="attr: {
-                src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion ?? 0)}.png?v=0.10.16`
+                src:`images/${filePath}.png`
               }" />
             </div>
           </td>
         </tr>
+        <!-- /ko -->
         <tr>
           <td>Region</td>
           <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></td>

--- a/pages/Towns/main.html
+++ b/pages/Towns/main.html
@@ -17,16 +17,18 @@
                         <img class="w-100" data-bind="attr: {src: `images/${Wiki.pageName()}.png`}"/>
                     </td>
                 </tr>
-                <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)">
+                <!-- ko with: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName(), $data.region, $data.subRegion), as: 'filePath' -->
+                <tr data-bind="with: Wiki.gameHelper.overlaySVG(), as: 'overlaySVG'">
                     <td colspan="2">
                         <div id="map-container">
-                            <div id="map-overlay" data-bind="if: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName())"></div>
+                            <div id="map-overlay" data-bind="html: overlaySVG"></div>
                             <img class="w-100" width="1600" data-bind="attr: {
-                                src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)}.png?v=0.10.16`
+                                src:`images/${filePath}.png?`
                             }" />
                         </div>
                     </td>
                 </tr>
+                <!-- /ko -->
                 <tr>
                     <td>Region</td>
                     <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region])"></td>

--- a/pages/Towns/main.html
+++ b/pages/Towns/main.html
@@ -4,7 +4,7 @@
         <h3>Town not found...</h3>
     <!-- /ko -->
     <!-- ko with: TownList[Wiki.pageName()] -->
-    <div class="float-lg-end col-lg-3 m-2">
+    <div class="float-lg-end col-lg-4 m-2">
         <table class="table table-hover table-striped table-bordered">
             <thead>
                 <tr>
@@ -15,6 +15,16 @@
                 <tr>
                     <td class="text-center" colspan="2">
                         <img class="w-100" data-bind="attr: {src: `images/${Wiki.pageName()}.png`}"/>
+                    </td>
+                </tr>
+                <tr data-bind="if: Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)">
+                    <td colspan="2">
+                        <div id="map-container">
+                            <div id="map-overlay" data-bind="if: Wiki.gameHelper.getLocationOverlaySVG(Wiki.pageName())"></div>
+                            <img class="w-100" width="1600" data-bind="attr: {
+                                src:`images/${Wiki.gameHelper.getRegionMap($data.region, $data.subRegion)}.png?v=0.10.16`
+                            }" />
+                        </div>
                     </td>
                 </tr>
                 <tr>

--- a/scripts/gameHelper.js
+++ b/scripts/gameHelper.js
@@ -209,8 +209,10 @@ const getRegionMap = (region, subregion) => {
 }
 
 let cachedPokeclickerHTML;
+let overlaySVG = ko.observable("");
 
 const fetchPokeclickerHTML = (mapLocationSelector) => {
+    overlaySVG("");
     if (!cachedPokeclickerHTML) {
         $.get('/pokeclicker/docs/index.html',
             function(data) {
@@ -223,14 +225,16 @@ const fetchPokeclickerHTML = (mapLocationSelector) => {
     }
 }
 
-const getLocationOverlaySVG = (town) => {
+const getLocationOverlaySVG = (town, region, subregion) => {
+    // Replace single quotes with their escaped versions
+    town = town.replaceAll(String.raw`'`, String.raw`\\'`)
     fetchPokeclickerHTML(`'${town}'`);
-    return true;
+    return getRegionMap(region, subregion);
 }
 
-const getRouteOverlaySVG = (route, region) => {
+const getRouteOverlaySVG = (route, region, subregion) => {
     fetchPokeclickerHTML(`moveToRoute(${route}, ${region})`);
-    return true;
+    return getRegionMap(region, subregion);
 }
 
 const setMapLocation = (selector) => {
@@ -254,14 +258,12 @@ const setMapLocation = (selector) => {
         const parent = firstTownNode.parentNode;
         parent.replaceChildren(...outputElements);
         map.replaceChildren(parent);
-        // Weird hack because sometimes manually created SVG elements don't render until they are messed with
-        map.innerHTML = map.innerHTML + "";
         // Scrub all the knockout bindings so they don't affect the rendering
         const allElements = map.querySelectorAll("*");
         allElements.forEach(element => {
             element.removeAttribute('data-bind');
         });
-        $('#map-overlay').html(map);
+        overlaySVG(map.outerHTML);
     }
 }
 
@@ -269,7 +271,7 @@ module.exports = {
     requirementHints,
     getEvolutionHints,
     getRegionName,
-    getRegionMap,
     getLocationOverlaySVG,
     getRouteOverlaySVG,
+    overlaySVG,
 }

--- a/scripts/gameHelper.js
+++ b/scripts/gameHelper.js
@@ -191,8 +191,85 @@ const getRegionName = (region) => {
     return GameConstants.camelCaseToString(GameConstants.Region[region]);
 };
 
+const getRegionMap = (region, subregion) => {
+    // There might be a way to grab these out of the HTML
+    const regionPNGs = [
+        ['kanto-kanto', 'kanto-sevii123', 'kanto-sevii4567' ],
+        ['johto'],
+        ['hoenn', 'orre'],
+        ['sinnoh'],
+        ['unova'],
+        ['kalos'],
+        ['alola-melemele', 'alola-akala', 'alola-ulaula', 'alola-poni', 'alola-magikarp-jump'],
+        ['galar-south', 'galar-north', 'galar-isle-of-armor', 'galar-crown-tundra'],
+        [], // hisui
+        [], // paldea
+    ];
+    return regionPNGs[region][subregion];
+}
+
+let cachedPokeclickerHTML;
+
+const fetchPokeclickerHTML = (mapLocationSelector) => {
+    if (!cachedPokeclickerHTML) {
+        $.get('/pokeclicker/docs/index.html',
+            function(data) {
+                cachedPokeclickerHTML = data;
+                setMapLocation(mapLocationSelector);
+            }
+        );
+    } else {
+        setMapLocation(mapLocationSelector);
+    }
+}
+
+const getLocationOverlaySVG = (town) => {
+    fetchPokeclickerHTML(`'${town}'`);
+    return true;
+}
+
+const getRouteOverlaySVG = (route, region) => {
+    fetchPokeclickerHTML(`moveToRoute(${route}, ${region})`);
+    return true;
+}
+
+const setMapLocation = (selector) => {
+    const dom = new DOMParser().parseFromString(cachedPokeclickerHTML, 'text/html');
+    const map = dom.querySelector('#map');
+
+    const locationElements = map.querySelectorAll(`[data-bind*="${selector}"]`);
+    if (locationElements.length > 0) {
+        const outputElements = [];
+        const firstTownNode = locationElements[0];
+
+        if (locationElements.length == 1 && firstTownNode.nodeName === "image") {
+            // If there is only one element and it's an image (due to being a dungeon-in-a-town), replace image with rect that we can fill
+            const newNode = document.createElement("rect");
+            [...firstTownNode.attributes].forEach(attr => newNode.setAttribute(attr.nodeName, attr.nodeValue));
+            outputElements.push(newNode);
+        } else {
+            outputElements.push(...locationElements);
+        }
+        // Create our own map mini-DOM with only the necessary elements
+        const parent = firstTownNode.parentNode;
+        parent.replaceChildren(...outputElements);
+        map.replaceChildren(parent);
+        // Weird hack because sometimes manually created SVG elements don't render until they are messed with
+        map.innerHTML = map.innerHTML + "";
+        // Scrub all the knockout bindings so they don't affect the rendering
+        const allElements = map.querySelectorAll("*");
+        allElements.forEach(element => {
+            element.removeAttribute('data-bind');
+        });
+        $('#map-overlay').html(map);
+    }
+}
+
 module.exports = {
     requirementHints,
     getEvolutionHints,
     getRegionName,
+    getRegionMap,
+    getLocationOverlaySVG,
+    getRouteOverlaySVG,
 }

--- a/scripts/gameHelper.js
+++ b/scripts/gameHelper.js
@@ -258,10 +258,13 @@ const setMapLocation = (selector) => {
         const parent = firstTownNode.parentNode;
         parent.replaceChildren(...outputElements);
         map.replaceChildren(parent);
-        // Scrub all the knockout bindings so they don't affect the rendering
         const allElements = map.querySelectorAll("*");
         allElements.forEach(element => {
+            // Scrub all the knockout bindings so they don't affect the rendering
             element.removeAttribute('data-bind');
+            // And all image hrefs
+            element.removeAttribute('href');
+            element.removeAttribute('xlink:href');
         });
         overlaySVG(map.outerHTML);
     }

--- a/styles.css
+++ b/styles.css
@@ -384,7 +384,6 @@ td.tight {
   opacity: 1;
 }
 
-
 .custom-tooltip {
   display: inline-block;
   position: relative;
@@ -401,4 +400,17 @@ td.tight {
 
 .custom-tooltip:hover .custom-tooltip-content {
   visibility: visible;
+}
+
+#map-container {
+  position: relative;
+}
+
+#map {
+  position: absolute;
+}
+
+#map rect {
+  fill: #ff00cc;
+  opacity: 0.6;
 }


### PR DESCRIPTION
Added the subregion map, as well as highlighting the specific area. Widened the right-hand summary box to make the map readable, have also added the summary box to the Routes page and moved Region/Subregion info there like it is for towns and dungeons.

Town:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/d4f8532e-c47c-4752-8b6e-7abb0a922b91)

Dungeon:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/afb23063-fd48-4cac-bef1-1009e9ab74f1)

Route:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/d6af294d-0295-4855-b473-7db67f4b0562)
