### PR TITLE
Add gender to Pokemon summary

### DIFF
--- a/data/Berries/Chilan.md
+++ b/data/Berries/Chilan.md
@@ -1,8 +1,7 @@
 ## Mutation Strategy {#mutation}
 
 ### Possible Planting Formations {#planting}
-Chilan Berries mutate when a Chople Berry is surrounded by atleast 3 or more Chople Berries.
-You can fill your farm in the following way to obtain Chilan Berries. Purple squares indicate where mutations can occur.
+Chilan Berries have a chance of mutating when a Chople Berry is surrounded by at least 3 or more Chople Berries. You can fill your farm in the following way to obtain Chilan Berries. Purple squares indicate where mutations can occur.
 
 **Base Formation**
 ::: table-mutations

--- a/styles.css
+++ b/styles.css
@@ -414,3 +414,27 @@ td.tight {
   fill: #ff00cc;
   opacity: 0.6;
 }
+
+.male{
+  background-color: rgb(100,100,255) !important;
+}
+
+.male:hover {
+    background-color: #2a63ec !important;
+}
+
+.female {
+  background-color: rgba(255,100,100) !important;
+}
+
+.female:hover {
+  background-color: #d83635 !important;
+}
+
+.genderless {
+  background-color: lightgray !important;
+}
+
+.genderless:hover {
+  background-color: gray !important;
+}

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -8,24 +8,24 @@
         <tr>
             <td class="text-center" colspan="2">
                 <table style="width: 100%;">
-                    <tr>
-                        <td data-bind="attr: { colspan: $data.gender.visualDifference ? 1 : 2 }">
+                    <div class="row">
+                        <div class="col">
                             <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
                             <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '.png'}"/>
-                        </td>
+                        </div>
                         <!-- ko if: $data.gender.visualDifference -->
-                        <td>
+                        <div class="col">
                             <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '-f.png'}"/>
                             <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '-f.png'}"/>
-                        </td>
+                        </div>
                         <!-- /ko -->
-                    </tr>
+                    </div>
                     <tr>
                         <!-- ko if: $data.gender.femaleRatio != 1 && $data.gender.type == GameConstants.Genders.MaleFemale -->
-                        <td data-bind="style:{width: PokedexHelper.getGenderRatioData($data).male + '%'}">♂</td>
+                        <td data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' }">♂</td>
                         <!-- /ko -->                
                         <!-- ko if: $data.gender.femaleRatio != 0 && $data.gender.type == GameConstants.Genders.MaleFemale -->
-                        <td data-bind="style:{width: PokedexHelper.getGenderRatioData($data).female + '%'}">♀</td>
+                        <td data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' }">♀</td>
                         <!-- /ko -->
                         <!-- ko if: $data.gender.type === GameConstants.Genders.Genderless -->
                         <td>Genderless</td>

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -9,6 +9,10 @@
             <td class="text-center" colspan="2">
                 <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
                 <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '.png'}"/>
+                <!-- ko if: $data.gender.visualDifference -->
+                <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '-f.png'}"/>
+                <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '-f.png'}"/>
+                <!-- /ko -->
             </td>
         </tr>
         <tr>

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -7,12 +7,64 @@
     <tbody>
         <tr>
             <td class="text-center" colspan="2">
-                <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
-                <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '.png'}"/>
-                <!-- ko if: $data.gender.visualDifference -->
-                <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '-f.png'}"/>
-                <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '-f.png'}"/>
-                <!-- /ko -->
+                <table style="width: 100%;">
+                    <tr>
+                        <td data-bind="attr: { colspan: $data.gender.visualDifference ? 1 : 2 }">
+                            <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
+                            <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '.png'}"/>
+                        </td>
+                        <!-- ko if: $data.gender.visualDifference -->
+                        <td>
+                            <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '-f.png'}"/>
+                            <img data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + $data.id + '-f.png'}"/>
+                        </td>
+                        <!-- /ko -->
+                    </tr>
+                    <tr>
+                        <!-- ko if: $data.gender.femaleRatio != 1 && $data.gender.type == GameConstants.Genders.MaleFemale -->
+                        <td data-bind="style:{width: PokedexHelper.getGenderRatioData($data).male + '%'}">♂</td>
+                        <!-- /ko -->                
+                        <!-- ko if: $data.gender.femaleRatio != 0 && $data.gender.type == GameConstants.Genders.MaleFemale -->
+                        <td data-bind="style:{width: PokedexHelper.getGenderRatioData($data).female + '%'}">♀</td>
+                        <!-- /ko -->
+                        <!-- ko if: $data.gender.type === GameConstants.Genders.Genderless -->
+                        <td>Genderless</td>
+                        <!-- /ko -->
+                    </tr>
+                    <!-- ko if: $data.gender.type != GameConstants.Genders.Genderless -->
+                    <tr>
+                        <td colspan="2">
+                            <div class="progress">
+                                <div class="progress-bar male" role="progressbar" aria-valuemax="100"
+                                data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' },
+                                tooltip: {
+                                    title:PokedexHelper.getGenderRatioData($data).male + '%',
+                                    placement: 'bottom'
+                                }"></div>
+                                <div class="progress-bar female" role="progressbar" aria-valuemax="100"
+                                data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' },
+                                tooltip: {
+                                    title:PokedexHelper.getGenderRatioData($data).female + '%',
+                                    placement: 'bottom'
+                                }"></div>
+                            </div>
+                        </td>
+                    </tr>
+                    <!-- /ko -->
+                    <!-- ko if: $data.gender.type === GameConstants.Genders.Genderless -->
+                    <tr>
+                        <td colspan="2">
+                            <div class="progress">
+                                <div class="progress-bar genderless" role="progressbar" style="width: 100%;" aria-valuemax="100" 
+                                data-bind="tooltip: {
+                                    title: 'N/A',
+                                    placement: 'bottom'
+                                }"></div>
+                            </div>
+                        </td>
+                    </tr>
+                    <!-- /ko -->
+                </table>
             </td>
         </tr>
         <tr>

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -7,7 +7,7 @@
     <tbody>
         <tr>
             <td class="text-center" colspan="2">
-                <table style="width: 100%;">
+                <div class="container">
                     <div class="row">
                         <div class="col">
                             <img class="mouseover-reveal" data-bind="attr: {src: './pokeclicker/docs/assets/images/shinypokemon/' + $data.id + '.png'}"/>
@@ -20,51 +20,45 @@
                         </div>
                         <!-- /ko -->
                     </div>
-                    <tr>
+                    <div class="row g-0">
                         <!-- ko if: $data.gender.femaleRatio != 1 && $data.gender.type == GameConstants.Genders.MaleFemale -->
-                        <td data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' }">♂</td>
-                        <!-- /ko -->                
+                        <div data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' }">♂</div>
+                        <!-- /ko -->
                         <!-- ko if: $data.gender.femaleRatio != 0 && $data.gender.type == GameConstants.Genders.MaleFemale -->
-                        <td data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' }">♀</td>
+                        <div data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' }">♀</div>
                         <!-- /ko -->
                         <!-- ko if: $data.gender.type === GameConstants.Genders.Genderless -->
-                        <td>Genderless</td>
+                        <div class="col">Genderless</div>
                         <!-- /ko -->
-                    </tr>
-                    <!-- ko if: $data.gender.type != GameConstants.Genders.Genderless -->
-                    <tr>
-                        <td colspan="2">
+                    </div>
+                    <div class="row">
+                        <div class="col">
                             <div class="progress">
+                                <!-- ko if: $data.gender.type != GameConstants.Genders.Genderless -->
                                 <div class="progress-bar male" role="progressbar" aria-valuemax="100"
-                                data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' },
-                                tooltip: {
-                                    title:PokedexHelper.getGenderRatioData($data).male + '%',
-                                    placement: 'bottom'
-                                }"></div>
+                                    data-bind="style: { width: PokedexHelper.getGenderRatioData($data).male + '%' },
+                                    tooltip: {
+                                        title:PokedexHelper.getGenderRatioData($data).male + '%',
+                                        placement: 'bottom'
+                                    }"></div>
                                 <div class="progress-bar female" role="progressbar" aria-valuemax="100"
-                                data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' },
-                                tooltip: {
-                                    title:PokedexHelper.getGenderRatioData($data).female + '%',
-                                    placement: 'bottom'
-                                }"></div>
-                            </div>
-                        </td>
-                    </tr>
-                    <!-- /ko -->
-                    <!-- ko if: $data.gender.type === GameConstants.Genders.Genderless -->
-                    <tr>
-                        <td colspan="2">
-                            <div class="progress">
+                                    data-bind="style: { width: PokedexHelper.getGenderRatioData($data).female + '%' },
+                                    tooltip: {
+                                        title:PokedexHelper.getGenderRatioData($data).female + '%',
+                                        placement: 'bottom'
+                                    }"></div>
+                                <!-- /ko -->
+                                <!-- ko if: $data.gender.type == GameConstants.Genders.Genderless -->
                                 <div class="progress-bar genderless" role="progressbar" style="width: 100%;" aria-valuemax="100" 
-                                data-bind="tooltip: {
-                                    title: 'N/A',
-                                    placement: 'bottom'
-                                }"></div>
+                                    data-bind="tooltip: {
+                                        title: 'N/A',
+                                        placement: 'bottom'
+                                    }"></div>
+                                <!-- /ko -->
                             </div>
-                        </td>
-                    </tr>
-                    <!-- /ko -->
-                </table>
+                        </div>
+                    </div>
+                </div>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Added gender to Pokemon pages. This includes:
- Female Sprites
- Gender ratio (% on hover)

![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/114451054/fcf70449-c04e-4164-ab50-92ca59296eb9)
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/114451054/4e42cc9c-a622-413b-892a-31d5020be78b)