### PR TITLE
Added Team to Dungeon Trainers

### DIFF
--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -69,13 +69,11 @@
         <br/>
         <div>
             <h3>Encounters</h3>
-            <!-- ko foreach: $data.enemyList -->
-                <!-- ko ifnot: $data.name -->
-                    <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == ($data.pokemon || $data)).id + '.png'}"/>
-                    <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.pokemon || $data, attr: { href: `#!Pokemon/${$data.pokemon || $data}` }"></a>
-                <!-- /ko -->              
+            <!-- ko foreach: $data.enemyList.filter(e => !e.name) -->
+            <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == ($data.pokemon || $data)).id + '.png'}"/>
+            <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.pokemon || $data, attr: { href: `#!Pokemon/${$data.pokemon || $data}` }"></a>            
             <!-- /ko -->
-            <div class="accordion" data-bind="visible: $data.enemyList.some(e => e.name)">
+            <div class="accordion mt-1" data-bind="visible: $data.enemyList.some(e => e.name)">
                 <div class="accordion-item">
                     <h4 class="accordion-header">
                         <button data-bs-target="#sectionCollapse" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
@@ -91,15 +89,9 @@
                                     html: false,
                                     trigger: 'hover'
                                 }"></span>
-                                (
-                                <!-- ko foreach: $data.team -->
-                                    <span data-bind="text: $data.name"></span>
-                                    <!-- ko if: $data.shadow >= GameConstants.ShadowStatus.Shadow -->
-                                        <img width="15px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>
-                                    <!-- /ko -->
-                                    <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
+                                <!-- ko with: $data.team.map((p) => `${p.name}${p.shadow ? '<img width="15px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>' : ''}`).join(', ') -->
+                                <span data-bind="html: `( ${$data} )`"></span>
                                 <!-- /ko -->
-                                )
                             </span>
                         </div>
                     </div>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -84,7 +84,12 @@
                     </h4>
                     <div id="sectionCollapse" class="accordion-body collapse" data-bind="foreach: $data.enemyList.filter((t) => t.team)">
                             <span class="badge text-bg-secondary">
-                            <span data-bind="text: $data.name"></span>
+                            <span data-bind="text: $data.name + `${$data.options ? ($data.options.requirement ? ' 🔒' : '') : ''}`,
+                            tooltip: {
+                                title: $data.options?.requirement ? Wiki.gameHelper.requirementHints($data.options.requirement, false).join('<br/>') : '',
+                                html: false,
+                                trigger: 'hover'
+                            }"></span>
                             (
                             <!-- ko foreach: $data.team -->
                                 <span data-bind="text: $data.name"></span>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -82,24 +82,26 @@
                             Trainers
                         </button>
                     </h4>
-                    <div id="sectionCollapse" class="accordion-body collapse" data-bind="foreach: $data.enemyList.filter((t) => t.team)">
+                    <div id="sectionCollapse" class="accordion-collapse collapse">
+                        <div class="accordion-body" data-bind="foreach: $data.enemyList.filter((t) => t.team)">
                             <span class="badge text-bg-secondary">
-                            <span data-bind="text: $data.name + `${$data.options ? ($data.options.requirement ? ' 🔒' : '') : ''}`,
-                            tooltip: {
-                                title: $data.options?.requirement ? Wiki.gameHelper.requirementHints($data.options.requirement, false).join('<br/>') : '',
-                                html: false,
-                                trigger: 'hover'
-                            }"></span>
-                            (
-                            <!-- ko foreach: $data.team -->
-                                <span data-bind="text: $data.name"></span>
-                                <!-- ko if: $data.shadow >= GameConstants.ShadowStatus.Shadow -->
-                                    <img width="15px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>
+                                <span data-bind="text: $data.name + `${$data.options ? ($data.options.requirement ? ' 🔒' : '') : ''}`,
+                                tooltip: {
+                                    title: $data.options?.requirement ? Wiki.gameHelper.requirementHints($data.options.requirement, false).join('<br/>') : '',
+                                    html: false,
+                                    trigger: 'hover'
+                                }"></span>
+                                (
+                                <!-- ko foreach: $data.team -->
+                                    <span data-bind="text: $data.name"></span>
+                                    <!-- ko if: $data.shadow >= GameConstants.ShadowStatus.Shadow -->
+                                        <img width="15px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>
+                                    <!-- /ko -->
+                                    <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
                                 <!-- /ko -->
-                                <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
-                            <!-- /ko -->
-                            )
+                                )
                             </span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -73,19 +73,28 @@
                 <!-- ko ifnot: $data.name -->
                     <img width="32px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonList.find((p) => p.name == ($data.pokemon || $data)).id + '.png'}"/>
                     <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.pokemon || $data, attr: { href: `#!Pokemon/${$data.pokemon || $data}` }"></a>
-                <!-- /ko -->
-                <!-- ko if: $data.name -->
-                    <span class="badge text-bg-secondary">
-                        <span  data-bind="text: $data.name"></span>
-                        (
-                        <!-- ko foreach: $data.team -->
-                        <span data-bind="text: $data.name"></span>
-                        <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
-                        <!-- /ko -->
-                        )
-                    </span>
-                <!-- /ko -->
+                <!-- /ko -->              
             <!-- /ko -->
+            <div class="accordion" data-bind="visible: $data.enemyList.filter((t) => t.team).length">
+                <div class="accordion-item">
+                    <h4 class="accordion-header">
+                        <button data-bs-target="#sectionCollapse" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
+                            Trainers
+                        </button>
+                    </h4>
+                    <div id="sectionCollapse" class="accordion-body collapse" data-bind="foreach: $data.enemyList.filter((t) => t.team)">
+                            <span class="badge text-bg-secondary">
+                            <span data-bind="text: $data.name"></span>
+                            (
+                            <!-- ko foreach: $data.team -->
+                                <span data-bind="text: $data.name"></span>
+                                <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
+                            <!-- /ko -->
+                            )
+                            </span>
+                    </div>
+                </div>
+            </div>
         </div>
         <br/>
         <!-- ko if: Wiki.dungeons.getDungeonShadowPokemon($data).length -->

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -75,7 +75,15 @@
                     <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.pokemon || $data, attr: { href: `#!Pokemon/${$data.pokemon || $data}` }"></a>
                 <!-- /ko -->
                 <!-- ko if: $data.name -->
-                    <span class="badge text-bg-secondary" data-bind="text: $data.name"></span>
+                    <span class="badge text-bg-secondary">
+                        <span  data-bind="text: $data.name"></span>
+                        (
+                        <!-- ko foreach: $data.team -->
+                        <span data-bind="text: $data.name"></span>
+                        <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
+                        <!-- /ko -->
+                        )
+                    </span>
                 <!-- /ko -->
             <!-- /ko -->
         </div>

--- a/pages/Dungeons/main.html
+++ b/pages/Dungeons/main.html
@@ -75,7 +75,7 @@
                     <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.pokemon || $data, attr: { href: `#!Pokemon/${$data.pokemon || $data}` }"></a>
                 <!-- /ko -->              
             <!-- /ko -->
-            <div class="accordion" data-bind="visible: $data.enemyList.filter((t) => t.team).length">
+            <div class="accordion" data-bind="visible: $data.enemyList.some(e => e.name)">
                 <div class="accordion-item">
                     <h4 class="accordion-header">
                         <button data-bs-target="#sectionCollapse" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
@@ -88,6 +88,9 @@
                             (
                             <!-- ko foreach: $data.team -->
                                 <span data-bind="text: $data.name"></span>
+                                <!-- ko if: $data.shadow >= GameConstants.ShadowStatus.Shadow -->
+                                    <img width="15px" class="ms-1" src="./pokeclicker/docs/assets/images/status/shadow.svg" title="Shadow"/>
+                                <!-- /ko -->
                                 <!-- ko if: $index() < $parent.team.length - 1 --><!-- ko text: ', ' --><!-- /ko --><!-- /ko -->
                             <!-- /ko -->
                             )


### PR DESCRIPTION
Added the Pokémon team to dungeon trainers in a collapsable section (collapsed by default). Also includes shadow icon if one of the Pokémon has that status and a lock if the trainer has requirements (hover for tooltip).

Example in an Orre dungeon:
![dungeon-trainer-1](https://github.com/pokeclicker/pokeclicker-wiki/assets/106291026/3e20df4e-caec-431b-a4d9-481dab307392)

Extended section:
![dungeon-trainer-2](https://github.com/pokeclicker/pokeclicker-wiki/assets/106291026/deace865-0e46-4ec9-a130-86242ba2fd98)

Tooltip:
![dungeon-trainer-3](https://github.com/pokeclicker/pokeclicker-wiki/assets/106291026/cc1b157d-5306-4bfd-9095-4aca5f10a103)