### PR TITLE
Hide unreleased regions

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79514,7 +79514,7 @@ const searchOptions = [
     type: 'Pokémon',
     page: '',
   },
-  ...Object.values(pokemonList).map(p => ({
+  ...Object.values(pokemonList).filter(p => Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION]).map(p => ({
     display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,
@@ -79530,7 +79530,7 @@ const searchOptions = [
     type: 'Dungeons',
     page: '',
   },
-  ...Object.values(dungeonList).map(d => ({
+  ...Object.values(dungeonList).filter(d => GameConstants.getDungeonRegion(d.name) <= GameConstants.MAX_AVAILABLE_REGION).map(d => ({
     display: d.name,
     type: 'Dungeons',
     page: d.name,
@@ -79636,7 +79636,7 @@ const searchOptions = [
     type: 'Regions',
     page: '',
   },
-  ...GameHelper.enumStrings(GameConstants.Region).filter(r => !['none', 'final'].includes(r)).map(r => ({
+  ...Object.entries(GameConstants.Region).filter(([region, regionName]) => region <= GameConstants.MAX_AVAILABLE_REGION && region >= 0).map(([region, regionName]) => regionName).map(r => ({
     display: GameConstants.camelCaseToString(r),
     type: 'Regions',
     page: GameConstants.camelCaseToString(r),
@@ -79647,7 +79647,7 @@ const searchOptions = [
     type: 'Towns',
     page: '',
   },
-  ...Object.values(TownList).filter(t => !(t instanceof DungeonTown) && !['Safari Zone', 'Friend Safari'].includes(t.name)).map(t => ({
+  ...Object.values(TownList).filter(t => !(t instanceof DungeonTown) && !['Safari Zone', 'Friend Safari'].includes(t.name) && t.region <= GameConstants.MAX_AVAILABLE_REGION).map(t => ({
     display: t.name,
     type: 'Towns',
     page: t.name,
@@ -79664,7 +79664,7 @@ const searchOptions = [
     type: 'Gyms',
     page: '',
   },
-  ...Object.entries(GymList).map(([key, gym]) => ({
+  ...Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
     display: gym.leaderName,
     type: 'Gyms',
     page: key,
@@ -79675,7 +79675,7 @@ const searchOptions = [
     type: 'Routes',
     page: '',
   },
-  ...Routes.regionRoutes.map(r => ({
+  ...Routes.regionRoutes.filter(r => r.region <= GameConstants.MAX_AVAILABLE_REGION).map(r => ({
     display: r.routeName,
     type: 'Routes',
     page: r.routeName,

--- a/pages/Berries/main.html
+++ b/pages/Berries/main.html
@@ -134,22 +134,24 @@
         </div>
         <h3>Wanderers</h3>
         <div class="table-responsive">
+            <!-- ko with: $data.wander.filter(p => Math.floor(pokemonMap[p].id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION]), as: 'wanderers' -->
             <table class="table table-hover table-striped table-bordered">
-                <tbody data-bind="foreach: new Array(Math.ceil($data.wander.length / 2))">
+                <tbody data-bind="foreach: new Array(Math.ceil(wanderers.length / 2))">
                     <tr>
                         <td>
-                            <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonMap[$parent.wander[$index() * 2]].id + '.png'}"/>
-                            <a data-bind="text: $parent.wander[$index() * 2], attr: { href: `#!Pokemon/${$parent.wander[$index() * 2]}` }"></a>
+                            <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonMap[wanderers[$index() * 2]].id + '.png'}"/>
+                            <a data-bind="text: wanderers[$index() * 2], attr: { href: `#!Pokemon/${wanderers[$index() * 2]}` }"></a>
                         </td>
-                        <!-- ko if: $parent.wander[$index() * 2 + 1] -->
+                        <!-- ko if: wanderers[$index() * 2 + 1] -->
                         <td>
-                            <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonMap[$parent.wander[$index() * 2 + 1]].id + '.png'}"/>
-                            <a data-bind="text: $parent.wander[$index() * 2 + 1], attr: { href: `#!Pokemon/${$parent.wander[$index() * 2 + 1]}` }"></a>
+                            <img width="48px" data-bind="attr: {src: './pokeclicker/docs/assets/images/pokemon/' + pokemonMap[wanderers[$index() * 2 + 1]].id + '.png'}"/>
+                            <a data-bind="text: wanderers[$index() * 2 + 1], attr: { href: `#!Pokemon/${wanderers[$index() * 2 + 1]}` }"></a>
                         </td>
                         <!-- /ko -->
                     </tr>
                 </tbody>
             </table>
+            <!-- /ko -->
         </div>
     </div>
     <!-- /ko -->

--- a/pages/Dungeon Tokens/overview.html
+++ b/pages/Dungeon Tokens/overview.html
@@ -14,7 +14,7 @@
                     <th>UB + MB</th>
                 </tr>
             </thead>
-            <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+            <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
                 <tr>
                     <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data])"></td>
                     <td data-bind="html: Wiki.dungeonTokens.highestRoute($data, 0)[0][0]"></td>
@@ -65,7 +65,7 @@
 <div>
     <h2>Regional Rate Tables</h2>
     <p>The following tables provide detailed information for every route, separated by region. DT represents the DT you gain per capture on each route, and the values underneath each Pokéball/Magic Ball combination represent the average Dungeon Tokens you will gain per second.</p>
-    <div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+    <div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
         <h4><a data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data]), attr: { href: `#!Regions/${GameConstants.camelCaseToString(GameConstants.Region[$data])}` }">Region</a></h4>
         <!-- ko if: $data != 7 -->
         <div class="table-responsive">
@@ -141,7 +141,7 @@
 <hr>
 <h2>Uses</h2>
 <h4>Dungeon Entry Cost</h4>
-<div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+<div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
     <h4><a data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data]), attr: { href: `#!Regions/${GameConstants.camelCaseToString(GameConstants.Region[$data])}` }">Region</a></h4>
 
     <div class="table-responsive">

--- a/pages/Dungeons/overview.html
+++ b/pages/Dungeons/overview.html
@@ -9,7 +9,7 @@
                 <th>Base HP</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: Object.values(dungeonList)">
+        <tbody data-bind="foreach: Object.values(dungeonList).filter(d => GameConstants.getDungeonRegion(d.name) <= GameConstants.MAX_AVAILABLE_REGION)">
             <tr class="text-nowrap clickable" data-bind="click: () => { Wiki.gotoPage('Dungeons', $data.name); return false; }">
                 <td data-bind="text: $data.name"></td>
                 <!-- ko with: Object.values(TownList).find(town => town.dungeon === $data) -->
@@ -39,7 +39,7 @@
                 <th>500 Times</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+        <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
             <tr data-bind="with: { region: GameConstants.camelCaseToString(GameConstants.Region[$data]), total: GameConstants.RegionDungeons[$data].map(d => dungeonList[d]).reduce((sum, d) => sum + d.tokenCost, 0) }">
                 <td data-bind="text: $data.region"></td>
                 <td data-bind="attr: { 'data-order': $data.total }"><img src="./images/dungeonToken.svg" width="18px"/> 

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -497,7 +497,7 @@
                             <th>Efficiency</th>
                         </tr>
                     </thead>
-                    <tbody data-bind="foreach: GameHelper.enumStrings(GameConstants.Region).filter(r => !['final'].includes(r))">
+                    <tbody data-bind="foreach: Object.entries(GameConstants.Region).filter(([region, regionName]) => region <= GameConstants.MAX_AVAILABLE_REGION && region >= 0).map(([region, regionName]) => regionName)">
                         <tr>
                             <td data-bind="text: GameConstants.camelCaseToString($data)"></td>
                             <td data-bind="text: (GameConstants.Region[$data] + 1) * 5"></td>

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -10,7 +10,7 @@
                 <th>Catch Rate</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: pokemonList.filter(p => p.id >= 0)">
+        <tbody data-bind="foreach: pokemonList.filter(p => p.id >= 0 && Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION])">
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Pokemon', $data.name); return false; }">
                 <td data-bind="text: `#${Math.floor($data.id).toString().padStart(3, '0')}`, attr: { 'data-sort': $data.id }"></td>
                 <td data-bind="text: $data.name"></td>

--- a/pages/Routes/overview.html
+++ b/pages/Routes/overview.html
@@ -12,7 +12,7 @@
                 <th>Roamer Chance</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: Routes.regionRoutes">
+        <tbody data-bind="foreach: Routes.regionRoutes.filter((route) => route.region <= GameConstants.MAX_AVAILABLE_REGION)">
             <tr class="text-nowrap clickable" data-bind="click: () => { Wiki.gotoPage('Routes', $data.routeName); return false; }">
                 <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region]), attr: { 'data-order': $data.region }"></td>
                 <td data-bind="text: SubRegions.list[$data.region][$data.subRegion ?? 0].name, attr: { 'data-order': $data.subRegion ?? 0 }"></td>

--- a/pages/Temporary Battles/overview.html
+++ b/pages/Temporary Battles/overview.html
@@ -9,7 +9,7 @@
             <th>Requirements</th>
         </tr>
     </thead>
-    <tbody data-bind="foreach: Object.keys(TemporaryBattleList)">
+    <tbody data-bind="foreach: Object.keys(TemporaryBattleList).filter(tb => TemporaryBattleList[tb].getTown().region <= GameConstants.MAX_AVAILABLE_REGION)">
         <tr class="clickable" data-bind="using: TemporaryBattleList[$data], click: () => { Wiki.gotoPage('Temporary Battles', $data); return true; }">
             <td class="align-middle" data-bind="text: $data.name"></td>
             <!-- ko ifnot: $data.optionalArgs?.returnTown -->

--- a/pages/Towns/overview.html
+++ b/pages/Towns/overview.html
@@ -10,7 +10,7 @@
             </tr>
         </thead>
         <tbody>
-            <!-- ko foreach: Object.values(TownList).filter(t => t.region < GameConstants.Region.final) -->
+            <!-- ko foreach: Object.values(TownList).filter(t => t.region <= GameConstants.MAX_AVAILABLE_REGION) -->
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Towns', $data.name); return false; }">
                 <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.region]), attr: { 'data-order': $data.region }"></td>
                 <td data-bind="text: SubRegions.list[$data.region][$data.subRegion ?? 0].name, attr: { 'data-order': $data.subRegion ?? 0 }"></td>

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -22,7 +22,7 @@ const searchOptions = [
     type: 'Pokémon',
     page: '',
   },
-  ...Object.values(pokemonList).map(p => ({
+  ...Object.values(pokemonList).filter(p => Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION]).map(p => ({
     display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,
@@ -38,7 +38,7 @@ const searchOptions = [
     type: 'Dungeons',
     page: '',
   },
-  ...Object.values(dungeonList).map(d => ({
+  ...Object.values(dungeonList).filter(d => GameConstants.getDungeonRegion(d.name) <= GameConstants.MAX_AVAILABLE_REGION).map(d => ({
     display: d.name,
     type: 'Dungeons',
     page: d.name,
@@ -144,7 +144,7 @@ const searchOptions = [
     type: 'Regions',
     page: '',
   },
-  ...GameHelper.enumStrings(GameConstants.Region).filter(r => !['none', 'final'].includes(r)).map(r => ({
+  ...Object.entries(GameConstants.Region).filter(([region, regionName]) => region <= GameConstants.MAX_AVAILABLE_REGION && region >= 0).map(([region, regionName]) => regionName).map(r => ({
     display: GameConstants.camelCaseToString(r),
     type: 'Regions',
     page: GameConstants.camelCaseToString(r),
@@ -155,7 +155,7 @@ const searchOptions = [
     type: 'Towns',
     page: '',
   },
-  ...Object.values(TownList).filter(t => !(t instanceof DungeonTown) && !['Safari Zone', 'Friend Safari'].includes(t.name)).map(t => ({
+  ...Object.values(TownList).filter(t => !(t instanceof DungeonTown) && !['Safari Zone', 'Friend Safari'].includes(t.name) && t.region <= GameConstants.MAX_AVAILABLE_REGION).map(t => ({
     display: t.name,
     type: 'Towns',
     page: t.name,
@@ -172,7 +172,7 @@ const searchOptions = [
     type: 'Gyms',
     page: '',
   },
-  ...Object.entries(GymList).map(([key, gym]) => ({
+  ...Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
     display: gym.leaderName,
     type: 'Gyms',
     page: key,
@@ -183,7 +183,7 @@ const searchOptions = [
     type: 'Routes',
     page: '',
   },
-  ...Routes.regionRoutes.map(r => ({
+  ...Routes.regionRoutes.filter(r => r.region <= GameConstants.MAX_AVAILABLE_REGION).map(r => ({
     display: r.routeName,
     type: 'Routes',
     page: r.routeName,


### PR DESCRIPTION
Implements simple and safe (i.e. err on the side of showing too much rather than too little) checking against `MAX_AVAILABLE_REGION` in both the search box and the content of pages

Notes:
* Goal is not to hide all unavailable/in-dev stuff (e.g. Gigantamaxes are still shown)
* Doesn't get rid of the actual pages for things like unreleased Pokémon, so you can still navigate directly by URL to edit if necessary
* One page I didn't touch is the [Regions](https://wiki.pokeclicker.com/#!Regions/) page, which still shows Hisui/Paldea with the (In Development) note