### PR TITLE
Fix transparent background on custom tooltip table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -414,3 +414,7 @@ td.tight {
   fill: #ff00cc;
   opacity: 0.6;
 }
+
+.custom-tooltip table {
+  background-color: var(--bs-body-bg);
+}


### PR DESCRIPTION
Sets the background color of tables in custom tooltips (pokemon summary) to match the body rather than be transparent.

Before:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/aa33b4c7-05c5-4a14-9270-3dab51a13a4b)

After:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/672420/bc9077a7-a29e-4dcb-9750-463f09f310b7)
