### PR TITLE
Add a cancel button the markdown editor

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77719,9 +77719,12 @@ window.Wiki = {
 },{"../pokeclicker/package.json":502,"./components":503,"./datatables":504,"./discord":505,"./game":506,"./gameHelper":507,"./markdown-renderer":514,"./navigation":515,"./notifications":516,"./pages/dealChains":517,"./pages/dreamOrbs":518,"./pages/dungeonTokens":519,"./pages/dungeons":520,"./pages/farm":521,"./pages/farmSimulator":522,"./pages/items":523,"./pages/oakItems":524,"./pages/pokemon":525,"./pages/shopMon":526,"./typeahead":528}],509:[function(require,module,exports){
 const { md } = require('./markdown-renderer');
 
+const getContent = (editor) => editor.value().split('\n').map(l => l.trimEnd()).join('\n');
+const getOriginalContent = (editor) => editor._rendered.value.split('\n').map(l => l.trimEnd()).join('\n');
+
 const saveChanges = (editor, filename, btn) => {
-  const content = editor.value().split('\n').map(l => l.trimEnd()).join('\n');
-  const originalContent = editor._rendered.value.split('\n').map(l => l.trimEnd()).join('\n');
+  const content = getContent(editor);
+  const originalContent = getOriginalContent(editor);
 
   // If nothing has changed, just return
   if (content == originalContent) {
@@ -77798,6 +77801,24 @@ const createMarkDownEditor =  (elementID, filename) => {
         defaultValue: (el) => {
           el.innerHTML = `Filename: <a class="text-decoration-none" target="_BLANK" href="https://github.com/pokeclicker/pokeclicker-wiki/tree/main/${filename}"><code>"${filename}"</code></a>`;
         },
+      },
+      {
+        className: 'cancel',
+        defaultValue: (el) => {
+          const btn = document.createElement('div');
+          btn.classList.add('btn', 'btn-danger', 'btn-sm');
+          btn.innerText = 'Cancel';
+          btn.onclick = () => {
+            let cancel = true;
+            if (getContent(mde) != getOriginalContent(mde)) {
+              cancel = confirm("There are unsaved changes which will be lost");
+            }
+            if (cancel) {
+              window.location.hash = window.location.hash.replace(/\/+edit$/, '');
+            }
+          }
+          el.append(btn);
+        }
       },
       {
         className: 'github',

--- a/scripts/markdown-editor.js
+++ b/scripts/markdown-editor.js
@@ -1,8 +1,11 @@
 const { md } = require('./markdown-renderer');
 
+const getContent = (editor) => editor.value().split('\n').map(l => l.trimEnd()).join('\n');
+const getOriginalContent = (editor) => editor._rendered.value.split('\n').map(l => l.trimEnd()).join('\n');
+
 const saveChanges = (editor, filename, btn) => {
-  const content = editor.value().split('\n').map(l => l.trimEnd()).join('\n');
-  const originalContent = editor._rendered.value.split('\n').map(l => l.trimEnd()).join('\n');
+  const content = getContent(editor);
+  const originalContent = getOriginalContent(editor);
 
   // If nothing has changed, just return
   if (content == originalContent) {
@@ -79,6 +82,24 @@ const createMarkDownEditor =  (elementID, filename) => {
         defaultValue: (el) => {
           el.innerHTML = `Filename: <a class="text-decoration-none" target="_BLANK" href="https://github.com/pokeclicker/pokeclicker-wiki/tree/main/${filename}"><code>"${filename}"</code></a>`;
         },
+      },
+      {
+        className: 'cancel',
+        defaultValue: (el) => {
+          const btn = document.createElement('div');
+          btn.classList.add('btn', 'btn-danger', 'btn-sm');
+          btn.innerText = 'Cancel';
+          btn.onclick = () => {
+            let cancel = true;
+            if (getContent(mde) != getOriginalContent(mde)) {
+              cancel = confirm("There are unsaved changes which will be lost");
+            }
+            if (cancel) {
+              window.location.hash = window.location.hash.replace(/\/+edit$/, '');
+            }
+          }
+          el.append(btn);
+        }
       },
       {
         className: 'github',


### PR DESCRIPTION
Adds a cancel button to the markdown editor with a confirmation box if there are unsaved changes

![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/a9158acd-fd3b-4b54-bff3-4f27cb805109)