### PR TITLE
Warnings to mention Oak Item interactions

### DIFF
--- a/data/Berries/Cornn.md
+++ b/data/Berries/Cornn.md
@@ -2,7 +2,7 @@
 
 ### Possible Planting Formations {#planting}
 
-You can fill your farm in the following way to obtain Cornn Berries. Purple squares indicate where mutations can occur.
+**WARNING:** Upon successfully mutating a Cornn, make sure to have [[Oak Items/Cell Battery]] unequipped since it may cause it to mutate into a [[Berries/Charti]].
 
 **Base Formation**
 ::: table-mutations

--- a/data/Berries/Pamtre.md
+++ b/data/Berries/Pamtre.md
@@ -2,6 +2,8 @@
 
 ### Possible Planting Formations {#planting}
 
+**WARNING:** Upon successfully mutating a Pamtre, make sure to have [[Oak Items/Rocky Helmet]] unequipped since it may cause it to mutate into a [[Berries/Kebia]].
+**WARNING:** While trying to mutate a Pamtre, make sure to have [[Oak Items/Cell Battery]] unequipped since it may cause it to mutate into a [[Berries/Charti]].
 You can fill your farm in the following way to obtain Pamtre Berries. Purple squares indicate where mutations can occur.
 
 **Base Formation**

--- a/data/Berries/Watmel.md
+++ b/data/Berries/Watmel.md
@@ -2,6 +2,7 @@
 
 ### Possible Planting Formations {#planting}
 
+**WARNING:** Upon successfully mutating a Watmel, make sure to have [[Oak Items/Sprinklotad]] unequipped since it may cause it to mutate into a [[Berries/Shuca]].
 You can fill your farm in the following way to obtain Watmel Berries. Purple squares indicate where mutations can occur.
 
 **Base Formation**


### PR DESCRIPTION
As I learned the hard way, a couple of the interactions were not listed on the wiki, while they are in other places (for example, Pamtre has no warnings about becoming a Kebia Berry, but Spelon has a warning about becoming a Chople berry. I took a quick glance through others and found Cornn becoming a Charti while trying to mutate Pamtre as well, and Watmel becoming a Shuca. These only have the prerequisites of "the berry exists on the farm and the oak item is equipped", so I think these alterations are fitting.