### PR TITLE
Added Base BE to Pokémon page

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -497,7 +497,7 @@
                             <th>Efficiency</th>
                         </tr>
                     </thead>
-                    <tbody data-bind="foreach: Object.entries(GameConstants.Region).filter(([region, regionName]) => region <= GameConstants.MAX_AVAILABLE_REGION && region >= 0).map(([region, regionName]) => regionName)">
+                    <tbody data-bind="foreach: Object.entries(GameConstants.Region).filter(([region, regionName]) => region <= GameConstants.MAX_AVAILABLE_REGION).sort((a, b) => a[0] - b[0]).map(([region, regionName]) => regionName)">
                         <tr>
                             <td data-bind="text: GameConstants.camelCaseToString($data)"></td>
                             <td data-bind="text: (GameConstants.Region[$data] + 1) * 5"></td>
@@ -505,7 +505,7 @@
                                 <td data-bind="text: $data.protein || '-'"></td>
                                 <td data-bind="text: $data.calcium || '-'"></td>
                                 <td data-bind="text: $data.carbos || '-'"></td>
-                                <td data-bind="text: $data.eff.toLocaleString('en-US', { maximumSignificantDigits: 3 })"></td>
+                                <td data-bind="text: $data.eff.toLocaleString('en-US', { maximumSignificantDigits: 2 })"></td>
                             <!-- /ko -->
                         </tr>
                     </tbody>

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -7,6 +7,7 @@
                 <th>Type</th>
                 <th>Base Attack</th>
                 <th>Egg Steps</th>
+                <th>Base BE</th>
                 <th>Catch Rate</th>
             </tr>
         </thead>
@@ -21,6 +22,7 @@
                 </td>
                 <td data-bind="text: $data.attack"></td>
                 <td data-bind="text: App.game.breeding.getSteps($data.eggCycles).toLocaleString(), attr: { 'data-order': $data.eggCycles }"></td>
+                <td data-bind="text: Wiki.pokemon.getEfficiency([0,0,0], $data.attack, $data.eggCycles).toLocaleString('en-US', { maximumSignificantDigits: 2 })"></td>
                 <td data-bind="text: PokemonFactory.catchRateHelper($data.catchRate, true) + '%'"></td>
             </tr>
         </tbody>


### PR DESCRIPTION
Added "Base BE" statistic in the main Pokémon page. Re-added None region in individual Pokémon pages since that one shows the Pokémon's BE with no Vitamins. Also, made maximumSignificantDigits be 2 instead of 3 since the game uses this value.