### PR TITLE
Add ability to default markdown collapsible blocks to collapsed state

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77938,14 +77938,15 @@ const md = new markdownit({
   .use(require('markdown-it-container'), 'collapse', {
 
     validate: function(params) {
-      return params.trim().match(/^collapse\s+(.*)$/);
+      return params.trim().match(/^collapsed?\s+(.*)$/);
     },
   
     render: function (tokens, idx) {
-      const m = tokens[idx].info.trim().match(/^collapse\s+(.*)$/);
-  
+      const m = tokens[idx].info.trim().match(/^collapsed?\s+(.*)$/);
+
       if (tokens[idx].nesting === 1) {
         const randID = Rand.string(5);
+        const startCollapsed = m[0].startsWith('collapsed');
         // opening tag
         return `
         <div class="accordion accordion-flush">
@@ -77955,7 +77956,7 @@ const md = new markdownit({
               ${md.utils.escapeHtml(m[1])}
               </button>
             </h2>
-            <div id="collapse-${randID}" class="accordion-collapse collapse show">
+            <div id="collapse-${randID}" class="accordion-collapse collapse ${!startCollapsed ? 'show' : ''}">
               <div class="accordion-body">\n`;
   
       } else {

--- a/scripts/markdown-renderer.js
+++ b/scripts/markdown-renderer.js
@@ -22,14 +22,15 @@ const md = new markdownit({
   .use(require('markdown-it-container'), 'collapse', {
 
     validate: function(params) {
-      return params.trim().match(/^collapse\s+(.*)$/);
+      return params.trim().match(/^collapsed?\s+(.*)$/);
     },
   
     render: function (tokens, idx) {
-      const m = tokens[idx].info.trim().match(/^collapse\s+(.*)$/);
-  
+      const m = tokens[idx].info.trim().match(/^collapsed?\s+(.*)$/);
+
       if (tokens[idx].nesting === 1) {
         const randID = Rand.string(5);
+        const startCollapsed = m[0].startsWith('collapsed');
         // opening tag
         return `
         <div class="accordion accordion-flush">
@@ -39,7 +40,7 @@ const md = new markdownit({
               ${md.utils.escapeHtml(m[1])}
               </button>
             </h2>
-            <div id="collapse-${randID}" class="accordion-collapse collapse show">
+            <div id="collapse-${randID}" class="accordion-collapse collapse ${!startCollapsed ? 'show' : ''}">
               <div class="accordion-body">\n`;
   
       } else {


### PR DESCRIPTION
Currently, collapsible blocks can be created in markdown by using `:::collapse`, these blocks will always default to being uncollapsed. This adds the ability to create collapsible blocks that default to collapsed by using `:::collapsed`.