### PR TITLE
Search suggestions are now proper links

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79906,6 +79906,9 @@ $('#search').typeahead({
   display: 'display',
   templates: {
     notFound: '<a class="dropdown-item disabled">No results found...</a>',
+    suggestion: (suggestion) => {
+      return `<a href="#!${suggestion.type}/${suggestion.page}">${suggestion.display}</a>`;
+    },
   },
 });
 $('#search').bind('typeahead:select', (ev, suggestion) => {

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -389,6 +389,9 @@ $('#search').typeahead({
   display: 'display',
   templates: {
     notFound: '<a class="dropdown-item disabled">No results found...</a>',
+    suggestion: (suggestion) => {
+      return `<a href="#!${suggestion.type}/${suggestion.page}">${suggestion.display}</a>`;
+    },
   },
 });
 $('#search').bind('typeahead:select', (ev, suggestion) => {


### PR DESCRIPTION
Changes the search suggestions to render as proper links so they can be opened in a new tab, middle clicked, etc.

Regular clicking keeps the same functionality it currently has.