### PR TITLE
Fix WeatherRequirements that are part of multirequirement

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77313,6 +77313,9 @@ themes.options.sort((a, b) => (a.text).localeCompare(b.text));
 // Suppress game notifications
 Notifier.notify = () => {};
 
+// Ensure weather never satisfies requirements so they are always shown
+Weather.currentWeather = () => -1;
+
 // Custom binds as these aren't loaded
 player = new Player();
 player.highestRegion(1);

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -13,6 +13,9 @@ themes.options.sort((a, b) => (a.text).localeCompare(b.text));
 // Suppress game notifications
 Notifier.notify = () => {};
 
+// Ensure weather never satisfies requirements so they are always shown
+Weather.currentWeather = () => -1;
+
 // Custom binds as these aren't loaded
 player = new Player();
 player.highestRegion(1);


### PR DESCRIPTION
Returning a weather that never matches so the requirement doesn't consider itself complete, fixes route encounter hints for Grapploct/Carracosta/Aurorus