### PR TITLE
Adjust Shadow Pokémon obtain method display

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -385,23 +385,21 @@
                 <!--
                     SHADOW POKEMON
                 -->
-                <!-- ko with: Wiki.pokemon.getAllAvailableShadowPokemon().filter(p => p.pokemon == Wiki.pageName()) -->
-                    <!-- ko if: $data.length -->
-                    <div class="accordion-item">
-                        <h4 class="accordion-header">
-                            <button data-bs-target="#obtain-method-shadow" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
-                                <img src="./images/Contagious.png" data-bind="tooltip: { title: 'Provides EVs' }"/>
-                                Shadow Pokémon
-                            </button>
-                        </h4>
-                        <div id="obtain-method-shadow" class="accordion-collapse collapse">
-                            <div class="accordion-body" data-bind="foreach: $data">
-                                <a class="badge text-bg-secondary" data-bind="text: `${$data.trainer.name} in ${$data.dungeon}`, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
-                            </div>
+                <!-- ko if: $data[PokemonLocationType.ShadowPokemon] -->
+                <div class="accordion-item">
+                    <h4 class="accordion-header">
+                        <button data-bs-target="#obtain-method-shadow" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
+                            <img src="./images/Contagious.png" data-bind="tooltip: { title: 'Provides EVs' }"/>
+                            Shadow Pokémon
+                        </button>
+                    </h4>
+                    <div id="obtain-method-shadow" class="accordion-collapse collapse">
+                        <div class="accordion-body" data-bind="foreach: $data[PokemonLocationType.ShadowPokemon]">
+                            <a class="badge text-bg-secondary" data-bind="text: `${$data}`, attr: { href: `#!Dungeons/${$data}` }"></a>
                         </div>
                     </div>
-                    <!-- /ko -->
-                <!-- /ko -->
+                </div>
+            <!-- /ko -->
 
                 <!--
                     BATTLE FRONTIER

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -353,6 +353,7 @@
 
                 <!--
                     FRIEND SAFARI
+                    TODO: Add Friend Safari to PokemonLocationType
                 -->
                 <!-- ko if: SafariPokemonList.list[GameConstants.Region.kalos]().find(p => p.name == Wiki.pageName()) ||
                     PokemonHelper.isObtainableAndNotEvable(Wiki.pageName()) && (PokemonHelper.calcNativeRegion(Wiki.pageName()) <= GameConstants.MAX_AVAILABLE_REGION) -->

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -400,7 +400,7 @@
                         </div>
                     </div>
                 </div>
-            <!-- /ko -->
+                <!-- /ko -->
 
                 <!--
                     BATTLE FRONTIER


### PR DESCRIPTION
Adjust the Shadow Pokémon obtain method to make use of the `PokemonLocationType`

We might need to adjust the data that is sent by this in the main game to provide the trainer similar to how the display was previously.