### PR TITLE
Add missing types to temporary battles that have no Pokémon requirements

### DIFF
--- a/pages/Temporary Battles/main.html
+++ b/pages/Temporary Battles/main.html
@@ -63,6 +63,11 @@
                         <knockout data-bind="text: $data.name"></knockout>
                     </td>
                     <td class="align-middle" data-bind="text: $data.maxHealth.toLocaleString()"></td>
+                    <td class="align-middle" data-bind="foreach: pokemonMap[$data.name].type">
+                        <span class="badge text-white" data-bind="text: PokemonType[$data], style: {
+                            backgroundColor: TypeColor[$data]
+                        }"></span>
+                    </td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Before:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/5e0d2876-a9d3-4402-ad5c-ea3b99e6c970)

After:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/fe65969d-3ba5-432b-98ae-408440dca518)
