### PR TITLE
Hide unreleased content 2: Electric Boogaloo

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -78901,7 +78901,7 @@ const getDungeonLoot = (dungeon) => {
 getDungeonLoot.cache = new WeakMap();
 
 const getDungeonLootChancesForItem = (itemName) => {
-    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
+    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => GameConstants.getDungeonRegion(d.name) <= GameConstants.MAX_AVAILABLE_REGION).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
     const dungeonsWithLootTables = dungeonsDroppingItem.map(dungeon => (
         {
             dungeonName: dungeon.name,

--- a/bundle.js
+++ b/bundle.js
@@ -79591,11 +79591,21 @@ const getAllAvailableShadowPokemon = () => {
         .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
 };
 
+const getAvailablePokemon = () => {
+    return pokemonList.filter(p =>
+        p.id >= 0 &&
+        Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION] &&
+        p.nativeRegion <= GameConstants.MAX_AVAILABLE_REGION &&
+        Object.keys(PokemonHelper.getPokemonLocations(p.name)).length
+    );
+}
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
+    getAvailablePokemon,
     getAllAvailableShadowPokemon,
 }
 
@@ -79682,6 +79692,7 @@ module.exports = {
 
 },{}],531:[function(require,module,exports){
 const { gotoPage } = require('./navigation');
+const { getAvailablePokemon } = require('./pages/pokemon');
 
 const searchOptions = [
   {
@@ -79705,7 +79716,7 @@ const searchOptions = [
     type: 'Pokémon',
     page: '',
   },
-  ...Object.values(pokemonList).filter(p => Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION]).map(p => ({
+  ...Object.values(getAvailablePokemon()).map(p => ({
     display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,

--- a/pages/Dungeons/overview.html
+++ b/pages/Dungeons/overview.html
@@ -53,7 +53,7 @@
             </tr>
         </tbody>
         <tfoot>
-            <tr data-bind="with: {total: Object.values(GameConstants.RegionDungeons).flat().map(d => dungeonList[d]).reduce((sum, d) => sum + d.tokenCost, 0)}">
+            <tr data-bind="with: {total: Object.values(GameConstants.RegionDungeons).filter((r, i) => i <= GameConstants.MAX_AVAILABLE_REGION).flat().map(d => dungeonList[d]).reduce((sum, d) => sum + d.tokenCost, 0)}">
                 <td>Total</td>
                 <td><img src="./images/dungeonToken.svg" width="18px"/> 
                     <ko data-bind="text: $data.total.toLocaleString()"></ko></td>

--- a/pages/Gems/main.html
+++ b/pages/Gems/main.html
@@ -17,7 +17,7 @@
                         <th>Location</th>
                     </tr>
                 </thead>
-                <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+                <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
                     <tr>
                         <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data])" rowspan="2" class="align-middle"></td>
                         <td>Gym</td>

--- a/pages/Pokémon Dollars/overview.html
+++ b/pages/Pokémon Dollars/overview.html
@@ -52,7 +52,7 @@
 <br/>
 <div>
     <h3>Regional Rate Tables</h3>
-    <div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r != GameConstants.Region.final && r != GameConstants.Region.none)">
+    <div data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
         <h3><a data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data]), attr: { href: `#!Regions/${GameConstants.camelCaseToString(GameConstants.Region[$data])}` }">Region</a></h3>
     
         <div class="table-responsive">

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -11,7 +11,7 @@
                 <th>Catch Rate</th>
             </tr>
         </thead>
-        <tbody data-bind="foreach: pokemonList.filter(p => p.id >= 0 && Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION])">
+        <tbody data-bind="foreach: Wiki.pokemon.getAvailablePokemon()">
             <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Pokemon', $data.name); return false; }">
                 <td data-bind="text: `#${Math.floor($data.id).toString().padStart(3, '0')}`, attr: { 'data-sort': $data.id }"></td>
                 <td data-bind="text: $data.name"></td>

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -242,7 +242,7 @@ const getDungeonLoot = (dungeon) => {
 getDungeonLoot.cache = new WeakMap();
 
 const getDungeonLootChancesForItem = (itemName) => {
-    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
+    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => GameConstants.getDungeonRegion(d.name) <= GameConstants.MAX_AVAILABLE_REGION).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
     const dungeonsWithLootTables = dungeonsDroppingItem.map(dungeon => (
         {
             dungeonName: dungeon.name,

--- a/scripts/pages/pokemon.js
+++ b/scripts/pages/pokemon.js
@@ -56,10 +56,20 @@ const getAllAvailableShadowPokemon = () => {
         .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
 };
 
+const getAvailablePokemon = () => {
+    return pokemonList.filter(p =>
+        p.id >= 0 &&
+        Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION] &&
+        p.nativeRegion <= GameConstants.MAX_AVAILABLE_REGION &&
+        Object.keys(PokemonHelper.getPokemonLocations(p.name)).length
+    );
+}
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
+    getAvailablePokemon,
     getAllAvailableShadowPokemon,
 }

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -1,4 +1,5 @@
 const { gotoPage } = require('./navigation');
+const { getAvailablePokemon } = require('./pages/pokemon');
 
 const searchOptions = [
   {
@@ -22,7 +23,7 @@ const searchOptions = [
     type: 'Pokémon',
     page: '',
   },
-  ...Object.values(pokemonList).filter(p => Math.floor(p.id) <= GameConstants.MaxIDPerRegion[GameConstants.MAX_AVAILABLE_REGION]).map(p => ({
+  ...Object.values(getAvailablePokemon()).map(p => ({
     display: `#${Math.floor(p.id).toString().padStart(3, '0')} - ${p.name}`,
     type: 'Pokémon',
     page: p.name,


### PR DESCRIPTION
Following on from #149 

Improves the logic for hiding unreleased Pokémon, so the main list is down to 1397 entries, which is the 1391 correct ones + 6 contest shop Pokémon which technically have an obtain location even though they are unobtainable. They would only be hideable with a hardcoded exclusion.

Removed unreleased regions from Pokédollars and Gems pages, and stopped them from counting towards the overall DT total on the Dungeon Tokens page
Edit: And hid unreleased region's dungeons from the Item dungeon drop tables