### PR TITLE
Restore Dungeon Drop tables to Underground item pages after the rework

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -78901,15 +78901,16 @@ const getDungeonLoot = (dungeon) => {
 getDungeonLoot.cache = new WeakMap();
 
 const getDungeonLootChancesForItem = (itemName) => {
-    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
+    const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
+    const lootName = item.displayName;
+
+    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName || l.loot == lootName)));
     const dungeonsWithLootTables = dungeonsDroppingItem.map(dungeon => (
         {
             dungeonName: dungeon.name,
             lootTable: getDungeonLoot(dungeon)
         }
     ));
-    const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
-    const lootName = item.displayName;
 
     // Collate and flatten all item-specific data from each dungeon's loot tables
     const itemData = [];

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -136,9 +136,9 @@
             </table>
         </div>
     </div>
-    <div class="mt-3" data-bind="if: pokemonList.some((p) => ([ItemType.item, ItemType.underground]).includes(p.heldItem?.type) && p.heldItem?.id == $data.name)">
+    <div class="mt-3" data-bind="if: pokemonList.some((p) => ([ItemType.item, ItemType.underground]).includes(p.heldItem?.type) && p.heldItem?.id == $data.name || p.heldItem?.id == $data.displayName)">
         <h3>Can be dropped by the following Pokémon:</h3>
-        <!-- ko foreach : pokemonList.filter((p) => ([ItemType.item, ItemType.underground]).includes(p.heldItem?.type) && p.heldItem?.id == $data.name) -->
+        <!-- ko foreach : pokemonList.filter((p) => ([ItemType.item, ItemType.underground]).includes(p.heldItem?.type) && p.heldItem?.id == $data.name || p.heldItem?.id == $data.displayName) -->
         <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Pokémon/${$data.name}` }"></a>
         <!-- /ko -->
     </div>

--- a/pages/Items/main.html
+++ b/pages/Items/main.html
@@ -88,7 +88,7 @@
             <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.name, attr: { href: `#!Towns/${$data.name}` }"></a>
         </div>
     </div>
-    <div class="mt-3" style="clear: right;" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name)))">
+    <div class="mt-3" style="clear: right;" data-bind="if: Object.values(dungeonList).some((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == $data.name || l.loot == $data.displayName)))">
         <h3>Can be found in the following dungeons:</h3>
         <p>Chance shown is for any given chest in the dungeon to contain the item.</p>
         <div class="table-responsive">

--- a/scripts/pages/dungeons.js
+++ b/scripts/pages/dungeons.js
@@ -242,15 +242,16 @@ const getDungeonLoot = (dungeon) => {
 getDungeonLoot.cache = new WeakMap();
 
 const getDungeonLootChancesForItem = (itemName) => {
-    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName)));
+    const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
+    const lootName = item.displayName;
+
+    const dungeonsDroppingItem = Object.values(dungeonList).filter((d) => Object.values(d.lootTable).some((lt) => lt.some((l) => l.loot == itemName || l.loot == lootName)));
     const dungeonsWithLootTables = dungeonsDroppingItem.map(dungeon => (
         {
             dungeonName: dungeon.name,
             lootTable: getDungeonLoot(dungeon)
         }
     ));
-    const item = UndergroundItems.getByName(itemName) ?? ItemList[itemName];
-    const lootName = item.displayName;
 
     // Collate and flatten all item-specific data from each dungeon's loot tables
     const itemData = [];


### PR DESCRIPTION
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/49700437-f0b1-4880-a827-2e009dc250ef)

Checked that it still works for various types of underground item/held item/battle item/etc.