### PR TITLE
Add the final missing Pokémon obtain locations

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79592,12 +79592,25 @@ const getAllAvailableShadowPokemon = () => {
         .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
 };
 
+const battleCafeToHumanReadableString = (battleCafeLocation) => {
+    const sweet = GameConstants.AlcremieSweet[battleCafeLocation.sweet];
+    const sweetString = sweet ? sweet : 'Any Sweet';
+
+    const spinEnum = GameHelper.enumStrings(GameConstants.AlcremieSpins)[battleCafeLocation.spin];
+    const splitCamelCase = GameConstants.camelCaseToString(spinEnum).replace('3600', ' 3600');
+    const commaSeperated = splitCamelCase.replaceAll(' ', ', ');
+    const relativeSeconds = commaSeperated.replace('Above5', '5 or more').replace('Above10', '11 or more').replace('Below5', 'Less than 5');
+    const spinWording = relativeSeconds.replace('At5', 'Dusk, Any').replace('Any', 'Any direction');
+    return `${sweetString} - ${spinWording} seconds`;
+};
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
     getAllAvailableShadowPokemon,
+    battleCafeToHumanReadableString,
 }
 
 },{}],529:[function(require,module,exports){

--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -28,10 +28,14 @@
                     text: $data"></a>
             <!-- /ko -->
         </div>
-        <div data-bind="visible: Object.entries(PokemonHelper.getPokemonLocations($data.name)).length">
+        <div>
             <h3>Obtain methods:</h3>
             <div class="accordion obtain-methods">
             <!-- ko with: PokemonHelper.getPokemonLocations($data.name) -->
+                <!-- ko if: Object.entries($data).length === 0 -->
+                <h4 data-bind="text: `${Wiki.pageName()} is not currently obtainable`"></h4>
+                <!-- /ko -->
+
                 <!--
                     ROUTES
                 -->
@@ -569,6 +573,75 @@
                                     placement: 'bottom',
                                     trigger: 'hover'
                                 }"></a>
+                        </div>
+                    </div>
+                </div>
+                <!-- /ko -->
+
+                <!--
+                    DREAM ORBS
+                -->
+                <!-- ko if: $data[PokemonLocationType.DreamOrb] -->
+                <div class="accordion-item">
+                    <h4 class="accordion-header">
+                        <button data-bs-target="#obtain-method-dreamorbs" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
+                            <img src="./images/Contagious.png" data-bind="tooltip: { title: 'Provides EVs' }"/>
+                            Dream Orbs
+                        </button>
+                    </h4>
+                    <div id="obtain-method-dreamorbs" class="accordion-collapse collapse">
+                        <div class="accordion-body" data-bind="foreach: Object.values($data[PokemonLocationType.DreamOrb])">
+                            <a href="#" class="badge text-bg-secondary" data-bind="text: $data, attr: { href: `#!Dream Orbs` }"></a>
+                        </div>
+                    </div>
+                </div>
+                <!-- /ko -->
+
+                <!--
+                    BATTLE CAFE
+                -->
+                <!-- ko if: $data[PokemonLocationType.BattleCafe] -->
+                <div class="accordion-item">
+                    <h4 class="accordion-header">
+                        <button data-bs-target="#obtain-method-battlecafe" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
+                            <img src="./images/Contagious.png" data-bind="tooltip: { title: 'Provides EVs' }"/>
+                            Battle Café
+                        </button>
+                    </h4>
+                    <div id="obtain-method-battlecafe" class="accordion-collapse collapse">
+                        <div class="accordion-body" data-bind="with: $data[PokemonLocationType.BattleCafe]">
+                            <a href="#" class="badge text-bg-secondary" data-bind="text: `${Wiki.pokemon.battleCafeToHumanReadableString($data)}`,
+                                attr: { href: `#!Battle Cafe` }"></a>
+                        </div>
+                    </div>
+                </div>
+                <!-- /ko -->
+
+                <!--
+                    SAFARI ITEM
+                -->
+                <!-- ko if: $data[PokemonLocationType.SafariItem] -->
+                <div class="accordion-item">
+                    <h4 class="accordion-header">
+                        <button data-bs-target="#obtain-method-safariitem" class="accordion-button collapsed" type="button" data-bs-toggle="collapse">
+                            <img src="./images/Contagious.png" data-bind="tooltip: { title: 'Provides EVs' }"/>
+                            Safari Item
+                        </button>
+                    </h4>
+                    <div id="obtain-method-safariitem" class="accordion-collapse collapse">
+                        <div class="accordion-body" data-bind="foreach: Object.entries($data[PokemonLocationType.SafariItem])">
+                            <h5 data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data[0]])"></h5>
+                            <p data-bind="with: $data[1]">
+                                <a class="badge text-bg-secondary" data-bind="text: `Chance ${$data.chance * 100}%${$data.requirement ? ' 🔒' : ''}`,
+                                    attr: { href: `#!Towns/${Object.values(TownList).find(t => t.region == $parent[0] && t.content.filter(c => c instanceof SafariTownContent).length).name}` },
+                                    tooltip: {
+                                        title: $data.requirement ?? '',
+                                        html: false,
+                                        placement: 'bottom',
+                                        trigger: 'hover'
+                                    }">
+                                </a>
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/scripts/pages/pokemon.js
+++ b/scripts/pages/pokemon.js
@@ -56,10 +56,23 @@ const getAllAvailableShadowPokemon = () => {
         .map(d => Wiki.dungeons.getDungeonShadowPokemon(d)).flat();
 };
 
+const battleCafeToHumanReadableString = (battleCafeLocation) => {
+    const sweet = GameConstants.AlcremieSweet[battleCafeLocation.sweet];
+    const sweetString = sweet ? sweet : 'Any Sweet';
+
+    const spinEnum = GameHelper.enumStrings(GameConstants.AlcremieSpins)[battleCafeLocation.spin];
+    const splitCamelCase = GameConstants.camelCaseToString(spinEnum).replace('3600', ' 3600');
+    const commaSeperated = splitCamelCase.replaceAll(' ', ', ');
+    const relativeSeconds = commaSeperated.replace('Above5', '5 or more').replace('Above10', '11 or more').replace('Below5', 'Less than 5');
+    const spinWording = relativeSeconds.replace('At5', 'Dusk, Any').replace('Any', 'Any direction');
+    return `${sweetString} - ${spinWording} seconds`;
+};
+
 module.exports = {
     getBreedingAttackBonus,
     calcEggSteps,
     getEfficiency,
     getBestVitamins,
     getAllAvailableShadowPokemon,
+    battleCafeToHumanReadableString,
 }


### PR DESCRIPTION
Complete the Obtain Locations menu on the Pokémon page:

Dream Orbs:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/72392a89-eec4-4761-b5c4-032acd13abc8)

Battle Café:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/be7af450-46e4-48a4-9130-2164ed67d7af)

Safari Item:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/f8042b05-d7f6-4578-b68f-0de7c55eb3af)

And a message for Pokémon without any obtain methods:
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/1eb36542-288d-48c7-8780-2606e97b09d0)