### PR TITLE
Add Maximum BE distributions to Vitamins page

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79553,37 +79553,30 @@ const getEfficiency = (vitaminsUsed, baseAttack, eggCycles) => {
 }
 
 const getBestVitamins = (baseAttack, eggCycles, region) => {
-    // Add our initial starting eff here
-    let res = {
-        protein: 0,
-        calcium: 0,
-        carbos: 0,
-        eff: getEfficiency([0,0,0], baseAttack, eggCycles),
-    };
-    vitaminsUsed = {};
-    totalVitamins = (region + 1) * 5;
-    // Unlocked at Unova
-    carbos = (region >= GameConstants.Region.unova ? totalVitamins : 0) + 1;
-    while (carbos-- > 0) {
-        // Unlocked at Hoenn
-        calcium = (region >= GameConstants.Region.hoenn ? totalVitamins - carbos: 0) + 1;
-        while (calcium-- > 0) {
-            protein = (totalVitamins - (carbos + calcium)) + 1;
-            while (protein-- > 0) {
-                const eff = getEfficiency([protein, calcium, carbos], baseAttack, eggCycles);
-                // If the previous result is better than this, no point to continue
-                if (eff < res.eff) break;
-                // Push our data if same or better
-                res = {
-                    protein,
-                    calcium,
-                    carbos,
-                    eff,
-                };
-            }
+    const maxVitamins = (region + 1) * 5;
+    // Only one attack vitamin ever makes sense for a given baseAttack
+    const attackVitamin = (baseAttack > 100 && region >= GameConstants.Region.hoenn) ? GameConstants.VitaminType.Calcium : GameConstants.VitaminType.Protein;
+    const startingCarbos = (region >= GameConstants.Region.unova ? maxVitamins : 0);
+    let bestVitamins = [0, 0, startingCarbos];
+    let bestEfficiency = getEfficiency(bestVitamins, baseAttack, eggCycles);
+    for (let i = 1; i <= maxVitamins; i++) {
+        const newVitamins = [0, 0, Math.max(startingCarbos - i, 0)];
+        newVitamins[attackVitamin] = i;
+        const newEfficiency = getEfficiency(newVitamins, baseAttack, eggCycles);
+        // Using >= here prioritises the cheaper attack vitamin over carbos when there is a dead tie
+        if (newEfficiency >= bestEfficiency) {
+            bestEfficiency = newEfficiency;
+            bestVitamins = newVitamins;
         }
     }
-    return res;
+
+    return {
+        protein: bestVitamins[GameConstants.VitaminType.Protein],
+        calcium: bestVitamins[GameConstants.VitaminType.Calcium],
+        carbos: bestVitamins[GameConstants.VitaminType.Carbos],
+        eggSteps: calcEggSteps(bestVitamins, eggCycles),
+        eff: bestEfficiency,
+    }
 }
 
 const getAllAvailableShadowPokemon = () => {

--- a/pages/Vitamins/overview.html
+++ b/pages/Vitamins/overview.html
@@ -28,6 +28,52 @@
             </tbody>
         </table>
     </div>
+</div>
+<div>
+    <h2 class="mt-3">Vitamins for Maximum Breeding Efficiency</h2>
+    <div data-bind="using: GameHelper.enumNumbers(GameConstants.Region).filter(r => r > -1 && r <= GameConstants.MAX_AVAILABLE_REGION)">
+        <ul class="nav nav-tabs" role="tablist" data-bind="foreach: $data">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" data-bs-toggle="tab" type="button" role="tab"
+                    data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data]), attr: { id: `tab-${$index()}`, 'data-bs-target': `#tab-${$index()}-pane` }, css: { active: $index() == GameConstants.MAX_AVAILABLE_REGION }"></button>
+            </li>
+        </ul>
+        <div class="tab-content mb-2" data-bind="foreach: $data">
+            <div class="tab-pane fade" role="tabpanel" data-bind="attr: { id: `tab-${$index()}-pane` }, css: { show: $index() == GameConstants.MAX_AVAILABLE_REGION, active: $index() == GameConstants.MAX_AVAILABLE_REGION }">
+                <h5 class="mt-2" data-bind="text: `In ${GameConstants.camelCaseToString(GameConstants.Region[$data])} you can use up to ${($data + 1)*5} vitamins per Pokémon.`"></h5>
+                <table class="table table-hover table-striped table-bordered">
+                    <thead class="thead-dark">
+                        <tr>
+                            <th class="col-1">Id</th>
+                            <th class="col-3">Pokémon</th>
+                            <th class="col-1 text-center">Protein</th>
+                            <th class="col-1 text-center">Calcium</th>
+                            <th class="col-1 text-center">Carbos</th>
+                            <th class="col-1 text-center">Egg Steps</th>
+                            <th class="col-2 text-center">Breeding Efficiency</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- ko foreach: pokemonList.filter(p => p.id > 0 && PokemonHelper.calcNativeRegion(p.name) <= $data) -->
+                        <tr>
+                            <td data-bind="text: `#${Math.floor($data.id).toString().padStart(3, '0')}`, attr: { 'data-sort': $data.id }"></td>
+                            <td data-bind="text: $data.name"></td>
+                            <!-- ko using: Wiki.pokemon.getBestVitamins($data.attack, $data.eggCycles, $parent) -->
+                            <td class="text-center" data-bind="text: $data.protein"></td>
+                            <td class="text-center" data-bind="text: $data.calcium"></td>
+                            <td class="text-center" data-bind="text: $data.carbos"></td>
+                            <td class="text-center" data-bind="text: $data.eggSteps"></td>
+                            <td class="text-center" data-bind="text: $data.eff.toLocaleString('en-US', { maximumSignificantDigits: 3, minimumSignificantDigits: 3 })"></td>
+                            <!-- /ko -->
+                        </tr>
+                        <!-- /ko -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+<div>
     <h2>Calculator</h2>
     <div class="table-responsive">
         <table class="table table-hover table-striped table-bordered">


### PR DESCRIPTION
Adds a table containing the vitamin usage for maximum BE to the vitamins page, with a region selector (defaults to Galar):
![image](https://github.com/pokeclicker/pokeclicker-wiki/assets/16630222/aa8809fd-b0c3-4837-b3f0-d87539996133)

Also optimised the Vitamin calculation function from ~O(n³) to O(n), when running against every Pokémon/region combo this brings it down from ~1000ms to ~50ms. The page unfortunately still chugs a bit on loading because KO insists on creating ten thousand individual bindings