### PR TITLE
NPCs

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79721,6 +79721,12 @@ const searchOptions = [
     type: 'Towns',
     page: t.name,
   })),
+  // NPCs
+  {
+    display: 'NPCs',
+    type: 'NPCs',
+    page: '',
+  },
   // Safari
   {
     display: 'Safari',

--- a/pages/NPCs/overview.html
+++ b/pages/NPCs/overview.html
@@ -1,0 +1,26 @@
+<div class="table-responsive">
+    <table class="table table-hover table-striped table-bordered" data-order="[]">
+        <thead class="thead-dark">
+            <tr>
+                <th>Name</th>
+                <th>Region</th>
+                <th>Sub Region</th>
+                <th>Town Name</th>
+                <th>Requirement</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- ko foreach: Object.values(TownList).filter(t => t.region <= GameConstants.MAX_AVAILABLE_REGION) -->
+            <!-- ko foreach: $data.npcs?.filter(npc => !(npc instanceof ProfNPC)) -->
+            <tr>
+                <td data-bind="text: name"></td>
+                <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$parent.region]), attr: { 'data-order': $parent.region }"></td>
+                <td data-bind="text: SubRegions.list[$parent.region][$parent.subRegion ?? 0].name, attr: { 'data-order': $parent.subRegion ?? 0 }"></td>
+                <td data-bind="text: $parent.name"></td>
+                <td data-bind="html: Wiki.md.renderInline(Wiki.gameHelper.requirementHints(options.requirement).join('\n'))"></td>
+            </tr>
+            <!-- /ko -->
+            <!-- /ko -->
+        </tbody>
+    </table>
+</div>

--- a/pages/NPCs/overview.html
+++ b/pages/NPCs/overview.html
@@ -12,7 +12,7 @@
         <tbody>
             <!-- ko foreach: Object.values(TownList).filter(t => t.region <= GameConstants.MAX_AVAILABLE_REGION) -->
             <!-- ko foreach: $data.npcs?.filter(npc => !(npc instanceof ProfNPC)) -->
-            <tr>
+            <tr class="clickable" data-bind="click: () => { Wiki.gotoPage('Towns', $parent.name); return false; }">
                 <td data-bind="text: name"></td>
                 <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$parent.region]), attr: { 'data-order': $parent.region }"></td>
                 <td data-bind="text: SubRegions.list[$parent.region][$parent.subRegion ?? 0].name, attr: { 'data-order': $parent.subRegion ?? 0 }"></td>

--- a/pages/home.html
+++ b/pages/home.html
@@ -2,6 +2,7 @@
 <div class="d-grid gap-2 d-sm-flex flex-wrap justify-content-sm-center align-items-center pb-2">
     <a href="#!Regions" class="btn btn-primary text-nowrap">Regions</a>
     <a href="#!Towns" class="btn btn-primary text-nowrap">Towns</a>
+    <a href="#!NPCs" class="btn btn-primary text-nowrap">NPCs</a>
     <a href="#!Routes" class="btn btn-primary text-nowrap">Routes</a>
     <a href="#!Gyms" class="btn btn-primary text-nowrap">Gyms</a>
     <a href="#!Dungeons" class="btn btn-primary text-nowrap">Dungeons</a>

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -166,6 +166,12 @@ const searchOptions = [
     type: 'Towns',
     page: t.name,
   })),
+  // NPCs
+  {
+    display: 'NPCs',
+    type: 'NPCs',
+    page: '',
+  },
   // Safari
   {
     display: 'Safari',


### PR DESCRIPTION
Made a NPCs page. Added button to main page next to Towns. Filtered ProfNPC because I considered it unnecessary. Individual pages do not currently exist due to how complex it was ~~for my current bad coding skills~~ due to NPCs not really having a unique ID so, instead, they link to the Town page they are located in for people to easily know where it's so they can then check in-game. If anything, should help with the "where is x NPC" for Quest Line purposes.

Looks like this:
![npcs](https://github.com/pokeclicker/pokeclicker-wiki/assets/106291026/229b4209-8ac4-4076-85e1-05790b6ee0de)
