### PR TITLE
Updated BE to Match the Game

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -684,7 +684,7 @@
                                 <td data-bind="text: $data.protein || '-'"></td>
                                 <td data-bind="text: $data.calcium || '-'"></td>
                                 <td data-bind="text: $data.carbos || '-'"></td>
-                                <td data-bind="text: $data.eff.toLocaleString('en-US', { maximumSignificantDigits: 2 })"></td>
+                                <td data-bind="text: $data.eff.toLocaleString('en-US', { maximumFractionDigits: 3 })"></td>
                             <!-- /ko -->
                         </tr>
                     </tbody>

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -23,7 +23,7 @@
                 </td>
                 <td data-bind="text: $data.attack"></td>
                 <td data-bind="text: App.game.breeding.getSteps($data.eggCycles).toLocaleString(), attr: { 'data-order': $data.eggCycles }"></td>
-                <td data-bind="text: Wiki.pokemon.getEfficiency([0,0,0], $data.attack, $data.eggCycles).toLocaleString('en-US', { maximumSignificantDigits: 2 })"></td>
+                <td data-bind="text: Wiki.pokemon.getEfficiency([0,0,0], $data.attack, $data.eggCycles).toLocaleString('en-US', { maximumFractionDigits: 3 })"></td>
                 <td data-bind="text: ($data.exp || 0).toLocaleString()"></td>
                 <td data-bind="text: PokemonFactory.catchRateHelper($data.catchRate, true) + '%'"></td>
             </tr>

--- a/pages/Vitamins/overview.html
+++ b/pages/Vitamins/overview.html
@@ -96,7 +96,7 @@
                 const baseOutput = 'efficiency-calculator-input-';
                 document.getElementById('efficiency-calculator-output-attack').innerText = attackBonus.toLocaleString();
                 document.getElementById('efficiency-calculator-output-egg-steps').innerText = eggSteps.toLocaleString();
-                document.getElementById('efficiency-calculator-output-efficiency').innerText = efficiency.toLocaleString('en-US', { maximumSignificantDigits: 3 });
+                document.getElementById('efficiency-calculator-output-efficiency').innerText = efficiency.toLocaleString('en-US', { maximumFractionDigits: 3 });
             }
             updateEfficiency();
         </script>


### PR DESCRIPTION
Breeding Efficiency was using `maximumSignificantDigits: 2` but latest update changed it to `maximumFractionDigits: 3` so this addresses it.