### PR TITLE
Farm Simulator - ability to import from pokeclicker save

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79173,6 +79173,21 @@ const importFarm = (str) => {
     });
 };
 
+const importFromFile = (file) => {
+    fileReader.readAsText(file);
+};
+
+const fileReader = new FileReader();
+fileReader.addEventListener('load', () => {
+    const saveData = JSON.parse(atob(fileReader.result));
+    const plotList = saveData.save.farming.plotList;
+    App.game.farming.plotList.forEach((plot, idx) => {
+        plot._berry(plotList[idx].berry);
+        plot._age(plotList[idx].age);
+        plot._mulch(plotList[idx].mulch);
+    });
+});
+
 let contextMenuSetup = false;
 let copiedPlot = { berry: BerryType.None, age: 0, mulch: MulchType.None };
 
@@ -79228,6 +79243,7 @@ module.exports = {
     clearAllPlots,
     exportFarm,
     importFarmPrompt,
+    importFromFile,
     showPlotContextMenu,
 }
 

--- a/pages/Farm Simulator/overview.html
+++ b/pages/Farm Simulator/overview.html
@@ -99,15 +99,22 @@
                 <hr class="my-2" />
                 <div class="d-flex justify-content-center align-items-center mt-2">
                     <input type="checkbox" class="btn-check" id="plot-labels-checkbox" autocomplete="off" data-bind="checked: Wiki.farmSimulator.plotLabelsEnabled">
-                    <label class="btn btn-secondary btn-sm me-auto" for="plot-labels-checkbox"
+                    <label class="btn btn-secondary btn-sm me-auto text-nowrap" for="plot-labels-checkbox"
                         data-bind="text: Wiki.farmSimulator.plotLabelsEnabled() ? '&check; Labels' : '&times; Labels'"></label>
-
-                    <button class="btn btn-sm btn-primary me-1" data-bind="click: () => { Wiki.farmSimulator.importFarmPrompt() }">Import</button>
+                    <input type="file" id="farmSimFileSelector" accept=".txt" class="d-none" onchange="Wiki.farmSimulator.importFromFile(this.files[0])">
+                    <div class="btn-group me-1">
+                        <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown">Import</button>
+                        <ul class="dropdown-menu">
+                            <li><button class="dropdown-item" type="button" data-bind="click: () => { Wiki.farmSimulator.importFarmPrompt() }">Import From Text</button></li>
+                            <li><button class="dropdown-item" type="button" data-bind="click: () => document.getElementById('farmSimFileSelector').click()">Import From Save</button></li>
+                        </ul>
+                    </div>
                     <button class="btn btn-sm btn-primary me-1" data-bind="click: () => { Wiki.farmSimulator.exportFarm() }">Export</button>
                     <button class="btn btn-sm btn-primary me-1" data-bind="click: () => { Wiki.farmSimulator.clearAllPlots() }">Clear</button>
                 </div>
             </div>
         </div>
+        <div class="text-muted small">* Right click a plot to copy/paste.</div>
     </div>
     <div class="col-12 col-lg-5">
         
@@ -245,7 +252,6 @@
         </div>
     </div>
 </div>
-<div class="text-muted small">* Right click a plot to copy/paste.</div>
 
 <div class="dropdown-menu dropdown-menu-sm dropdown-menu-dark" id="plot-context-menu">
     <button class="dropdown-item" data-action="copy">Copy</button>

--- a/scripts/pages/farmSimulator.js
+++ b/scripts/pages/farmSimulator.js
@@ -259,6 +259,21 @@ const importFarm = (str) => {
     });
 };
 
+const importFromFile = (file) => {
+    fileReader.readAsText(file);
+};
+
+const fileReader = new FileReader();
+fileReader.addEventListener('load', () => {
+    const saveData = JSON.parse(atob(fileReader.result));
+    const plotList = saveData.save.farming.plotList;
+    App.game.farming.plotList.forEach((plot, idx) => {
+        plot._berry(plotList[idx].berry);
+        plot._age(plotList[idx].age);
+        plot._mulch(plotList[idx].mulch);
+    });
+});
+
 let contextMenuSetup = false;
 let copiedPlot = { berry: BerryType.None, age: 0, mulch: MulchType.None };
 
@@ -314,5 +329,6 @@ module.exports = {
     clearAllPlots,
     exportFarm,
     importFarmPrompt,
+    importFromFile,
     showPlotContextMenu,
 }


### PR DESCRIPTION
Adds the ability to import the farm from a pokeclicker save to the farm simulator