### PR TITLE
Added Native Region to Pokémon pages

### DIFF
--- a/data/Pokémon/overview_description.md
+++ b/data/Pokémon/overview_description.md
@@ -16,13 +16,13 @@ Base attack = √(Base Defense \* Base stamina) \* (Base offense/250)
 * This value is floored.
 *This formula means that all Pokémon stats contribute to Pokémon attack, but not in the same amount. HP and attack values are more significant than defense or speed.*
 
-#### Attack
+### Attack
 
 When first caught, a Pokémon will, at level 100, have an Attack stat equal to their Base Attack. Beneath level 100, their Attack scales linearly from 0 to their maximum Attack. However, at no point may a Pokémon’s Attack be less than 1.
 
 Total Pokémon attack will increase while breeding according to the attack bonus.
 
-##### Attack Bonus
+### Attack Bonus
 
 The attack bonus is the extra damage that a Pokémon will get each breeding cycle.
 This is **always** calculated using the base attack, not the current attack.
@@ -33,7 +33,7 @@ The **Attack bonus** can be increased using 2 different [[Vitamins]]: [[Items/Pr
 * **Protein** gives +1 attack bonus. *In our example, Metapod will have 6 attack bonus after using 1 Protein and 15 attack bonus after using 10 Proteins. While Pidgeot (with 112 base attack) will have 29 attack bonus after 1 Protein and 38 after 10 Proteins.*
 * **Calcium** gives 1% base attack as attack bonus. *In our example, Metapod will have 5.2 attack bonus after 1 Calcium and 7 attack bonus after 10 Calcium. While Pidgeot will have 29.12 attack bonus after 1 Calcium and 39.2 after 10 Calcium.*
 
-#### Breeding Efficiency (BE)
+### Breeding Efficiency (BE)
 A Pokémon with a high base attack and a low number of egg steps will have a high Breeding Efficiency stat, which is calculated with the following formula:
 
 $BE = \frac{Attack Bonus}{Egg Cycles} * EV Bonus * Shadow Status * Held Item Bonus$
@@ -61,13 +61,16 @@ There are exceptions to this rule:
 * Although [[Mega Pokémon]] are technically evolutions, they share the same egg cycle value as their counterpart.
 * [[Pokémon/Elf Munchlax]] acts as a Baby Pokémon of [[Pokémon/Santa Snorlax]], in regard of its egg cycle value, but is not.
 
-#### Click Attack
+### Native Region
+Native Region doesn't necessarily refer to when the Pokémon is available but rather the Region the game considers it for Pokédex completion and Regional Debuff calculations.
+
+## Click Attack
 Besides [[Achievements]], Pokémon also contribute to the player's click attack value. The formula used is the following:
 $ClickAttack=⌊(1 + achievementBonus) * (numCaught + numShiny + numResistant + numPurified + 1) ^ {1.4}⌋$
 
 Where **numCaught**, **numShiny**,  **numResistant**, and **numPurified** refers to the number of unique captured Pokémon, unique shiny Pokémon, unique Pokémon resisted, and unique Pokémon purified respectively.
 
-### Other Pokémon Lists
+## Other Pokémon Lists
 - [[Alternate Pokémon Forms]] page lists all alternate forms available in the game, including Regional forms, and the corresponding base Pokémon.
 - [[Mega Pokémon]] page has details about which Pokémon can Mega Evolve and the requirements necessary to do so.
 - [[Baby Pokémon]] page has a list of all Baby Pokémon available in the game and the Region needed to acquire them.

--- a/pages/Pokémon/overview.html
+++ b/pages/Pokémon/overview.html
@@ -10,6 +10,7 @@
                 <th>Base BE</th>
                 <th>Experience</th>
                 <th>Catch Rate</th>
+                <th>Native Region</th>
             </tr>
         </thead>
         <tbody data-bind="foreach: Wiki.pokemon.getAvailablePokemon()">
@@ -26,6 +27,7 @@
                 <td data-bind="text: Wiki.pokemon.getEfficiency([0,0,0], $data.attack, $data.eggCycles).toLocaleString('en-US', { maximumFractionDigits: 3 })"></td>
                 <td data-bind="text: ($data.exp || 0).toLocaleString()"></td>
                 <td data-bind="text: PokemonFactory.catchRateHelper($data.catchRate, true) + '%'"></td>
+                <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.nativeRegion])"></td>
             </tr>
         </tbody>
     </table>

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -89,6 +89,10 @@
             <td>Catch Rate</td>
             <td data-bind="text: PokemonFactory.catchRateHelper($data.catchRate, true) + '%'"></td>
         </tr>
+        <tr>
+            <td>Native Region</td>
+            <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data.nativeRegion])"></td>
+        </tr>
         <tr data-bind="if: $data.heldItem">
             <td>Rare Hold Item</td>
             <td>


### PR DESCRIPTION
Added Native Region to the main and individual Pokémon pages. Also added a section below Egg Steps but before Click Attack about what Native Region refers to.

Moved heading sizes because they were all over the place.