### PR TITLE
Add region to Dungeon and Dungeon Boss pokemon obtain locations

### DIFF
--- a/pages/Pokémon/main.html
+++ b/pages/Pokémon/main.html
@@ -117,20 +117,28 @@
                         </button>
                     </h4>
                     <div id="obtain-method-dungeon" class="accordion-collapse collapse">
-                        <div class="accordion-body d-flex flex-wrap gap-2" data-bind="foreach: Object.values($data[PokemonLocationType.Dungeon])">
-                            <div class="input-group input-group-sm w-auto">
-                                <span class="input-group-text">
-                                    <a class="text-decoration-none text-body" data-bind="
-                                        text: $data.dungeon, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
-                                </span>
-                                <!-- ko if: $data.requirements -->
-                                <span class="input-group-text" style="cursor: help" data-bind="tooltip: {
-                                    title: $data.requirements ?? '',
-                                    html: false,
-                                    placement: 'bottom',
-                                    trigger: 'hover'
-                                }">🔒</span>
-                                <!-- /ko -->
+                        <div class="accordion-body" data-bind="foreach: Object.entries($data[PokemonLocationType.Dungeon].reduce((a, d) => {
+                            const region = TownList[d.dungeon].region;
+                            a[region] = a[region] || [];
+                            a[region].push(d);
+                            return a;
+                        }, {}))">
+                            <h5 data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data[0]])"></h5>
+                            <div class="d-flex flex-wrap gap-2 mb-2" data-bind="foreach: $data[1]">
+                                <div class="input-group input-group-sm w-auto">
+                                    <span class="input-group-text">
+                                        <a class="text-decoration-none text-body" data-bind="
+                                            text: $data.dungeon, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
+                                    </span>
+                                    <!-- ko if: $data.requirements -->
+                                    <span class="input-group-text" style="cursor: help" data-bind="tooltip: {
+                                        title: $data.requirements ?? '',
+                                        html: false,
+                                        placement: 'bottom',
+                                        trigger: 'hover'
+                                    }">🔒</span>
+                                    <!-- /ko -->
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -149,20 +157,28 @@
                         </button>
                     </h4>
                     <div id="obtain-method-dungeon-boss" class="accordion-collapse collapse">
-                        <div class="accordion-body d-flex flex-wrap gap-2" data-bind="foreach: Object.values($data[PokemonLocationType.DungeonBoss])">
-                            <div class="input-group input-group-sm w-auto">
-                                <span class="input-group-text">
-                                    <a class="text-decoration-none text-body" data-bind="
-                                        text: $data.dungeon, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
-                                </span>
-                                <!-- ko if: $data.requirements -->
-                                <span class="input-group-text" style="cursor: help" data-bind="tooltip: {
-                                    title: $data.requirements ?? '',
-                                    html: false,
-                                    placement: 'bottom',
-                                    trigger: 'hover'
-                                }">🔒</span>
-                                <!-- /ko -->
+                        <div class="accordion-body" data-bind="foreach: Object.entries($data[PokemonLocationType.DungeonBoss].reduce((a, d) => {
+                            const region = TownList[d.dungeon].region;
+                            a[region] = a[region] || [];
+                            a[region].push(d);
+                            return a;
+                        }, {}))">
+                            <h5 data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data[0]])"></h5>
+                            <div class="d-flex flex-wrap gap-2 mb-2" data-bind="foreach: $data[1]">
+                                <div class="input-group input-group-sm w-auto">
+                                    <span class="input-group-text">
+                                        <a class="text-decoration-none text-body" data-bind="
+                                            text: $data.dungeon, attr: { href: `#!Dungeons/${$data.dungeon}` }"></a>
+                                    </span>
+                                    <!-- ko if: $data.requirements -->
+                                    <span class="input-group-text" style="cursor: help" data-bind="tooltip: {
+                                        title: $data.requirements ?? '',
+                                        html: false,
+                                        placement: 'bottom',
+                                        trigger: 'hover'
+                                    }">🔒</span>
+                                    <!-- /ko -->
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Changes the Dungeon and Dungeon Boss obtain location display to group the dungeons by region, like the Route display

![image](https://github.com/user-attachments/assets/6b31cff5-8f1f-4af4-bb19-d44ceea2700e)
