### PR TITLE
Berry prev/next paging

### DIFF
--- a/pages/Berries/main.html
+++ b/pages/Berries/main.html
@@ -5,6 +5,16 @@
     <!-- ko if: BerryType[Wiki.pageName()] >= 0 -->
     <div data-bind="with: App.game.farming.berryData[BerryType[Wiki.pageName()]]">
         <div class="float-lg-end col-lg-3 m-2">
+            <div class="d-flex justify-content-between mb-1" data-bind="using: BerryType[Wiki.pageName()]">
+                <div data-bind="with: App.game.farming.berryData[$data - 1]">
+                    <button class="btn btn-link btn-sm" type="button" style="text-decoration: none;"
+                        data-bind="text: `← ${BerryType[$data.type]}`, click: () => Wiki.gotoPage('Berries', BerryType[$data.type])"></button>
+                </div>
+                <div data-bind="with: BerryType[$data + 1]">
+                    <button class="btn btn-link btn-sm" type="button" style="text-decoration: none;"
+                        data-bind="text: `${$data} →`, click: () => Wiki.gotoPage('Berries', $data)"></button>
+                </div>
+            </div>
             <table class="table table-hover table-striped table-bordered">
                 <thead>
                     <tr>


### PR DESCRIPTION
Adds prev/next paging to the berry pages like the Pokemon page has

![image](https://github.com/user-attachments/assets/c7f84f0a-3006-488c-88b0-a7cc5e9bfc73)
![image](https://github.com/user-attachments/assets/0e180aeb-8979-4f33-a708-c31066a6d06a)
![image](https://github.com/user-attachments/assets/1cf27c87-9196-4ceb-b1e9-842d941b6962)
