### PR TITLE
Improved Gem pages, Type-catch quest pages, requirements fix

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -77325,8 +77325,8 @@ themes.options.sort((a, b) => (a.text).localeCompare(b.text));
 // Suppress game notifications
 Notifier.notify = () => {};
 
-// Ensure weather never satisfies requirements so they are always shown
-Weather.currentWeather = () => -1;
+// Ensure requirements are never satisfied so they are always shown
+Requirement.prototype.isCompleted = () => false;
 
 // Not sure why but this was causing an error on load after the v0.10.22 update
 SortModules = () => {};

--- a/data/Catch Type Quests/overview_description.md
+++ b/data/Catch Type Quests/overview_description.md
@@ -1,0 +1,5 @@
+"Capture or Hatch X-type Pokémon" quests are random repeatable quests that can be completed for [[Quest Points]].
+
+These quests can be completed by filtering the [[Hatchery]] to the specific type, and by going to [[Routes]] that have a large number of that type.
+
+The best routes to farm can be found by choosing a type below

--- a/pages/Catch Type Quests/main.html
+++ b/pages/Catch Type Quests/main.html
@@ -1,0 +1,75 @@
+<div>
+    <!-- ko ifnot: PokemonType[Wiki.pageName()] >= 0 -->
+    <h3>Pokémon type not found...</h3>
+    <!-- /ko -->
+    <!-- ko if: PokemonType[Wiki.pageName()] >= 0 -->
+    <div data-bind="with: Wiki.pageName()">
+        <h3 data-bind="text: `Best locations for completing Capture ${$data}-type Pokémon quests`"></h3>
+        <p>The top two locations from each Region are listed below, if they exist.</p>
+        <p>Current weather and day of week are taken into account for Route encounters, but other requirements (such as previously caught) are assumed to be met.</p>
+        <p>The number shown is the chance that any single encounter on that route will be a successful catch of the desired type, while using the equipment specified.</p>
+        <div class="table-responsive">
+            <table class="table table-hover table-striped table-bordered">
+                <thead class="thead-dark">
+                    <tr>
+                        <th class="align-middle">Region</th>
+                        <th class="align-middle">Current Weather</th>
+                        <th class="align-middle">Location</th>
+                        <th class="align-middle" style="text-align: right;">Maximum HP</th>
+                        <th class="align-middle" style="text-align: right; width: 15%;">
+                            <img width="24" class="me-1" src="./pokeclicker/docs/assets/images/pokeball/Pokeball.svg" data-bind="tooltip: {
+                                title: 'Poké Ball',
+                                trigger: 'hover'
+                            }">
+                        </th>
+                        <th class="align-middle" style="text-align: right; width: 15%;">
+                            <img width="24" class="me-1" src="./pokeclicker/docs/assets/images/pokeball/Pokeball.svg" data-bind="tooltip: {
+                                title: 'Poké Ball',
+                                trigger: 'hover'
+                            }"> +
+                            <img width="32" class="me-1" src="./images/Magic_Ball.png" data-bind="tooltip: {
+                                title: 'Magic Ball (Level 5)',
+                                trigger: 'hover'
+                            }">
+                            or&nbsp;
+                            <img width="24" class="me-1" src="./pokeclicker/docs/assets/images/pokeball/Ultraball.svg" data-bind="tooltip: {
+                                title: 'Ultra Ball',
+                                trigger: 'hover'
+                            }">
+                        </th>
+                        <th class="align-middle" style="text-align: right; width: 15%;">
+                            <img width="24" class="me-1" src="./pokeclicker/docs/assets/images/pokeball/Ultraball.svg" data-bind="tooltip: {
+                                title: 'Ultra Ball',
+                                trigger: 'hover'
+                            }"> +
+                            <img width="32" class="me-1" src="./images/Magic_Ball.png" data-bind="tooltip: {
+                                title: 'Magic Ball (Level 5)',
+                                trigger: 'hover'
+                            }">
+                        </th>
+                    </tr>
+                </thead>
+                <tbody
+                    data-bind="foreach: { data: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none), as: 'region' }">
+                    <!-- ko foreach: Wiki.gems.bestCaptureRoutesPerRegion(region, PokemonType[$parent]) -->
+                    <tr>
+                        <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[region]), attr: { 'data-sort': region }"></td>
+                        <td class="align-middle text-center tight" style="box-shadow: none; border: none;" data-bind="style: { 'background-color': Weather.weatherConditions[$data.weather].color, display: 'flex', width: 'auto' }">
+                            <img data-bind="attr: { src: `./pokeclicker/docs/assets/images/weather/${WeatherType[$data.weather]}.png` }"
+                                width="24px">
+                            <ko data-bind="text: GameConstants.humanifyString(WeatherType[$data.weather])"></ko>
+                        </td>
+                        <td><a class="text-nowrap" style="text-decoration: none;" data-bind="text: $data.route.routeName.replace(), attr: { href: `#!Routes/${$data.route.routeName}` }"></a></td>
+                        <td class="text-nowrap" style="text-align: right;" data-bind="text: `${$data.maxHealth.toLocaleString()} ❤️`, attr: { 'data-sort' : $data.maxHealth }"></td>
+                        <td style="text-align: right;" data-bind="text: `${($data.pokeball / 100).toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, attr: { 'data-sort': $data.pokeball }"></td>
+                        <td style="text-align: right;" data-bind="text: `${($data.ultraball / 100).toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, attr: { 'data-sort': $data.ultraball }"></td>
+                        <td style="text-align: right;" data-bind="text: `${($data.ultraballMagicBall / 100).toLocaleString(undefined, { style: 'percent', minimumFractionDigits: 2, maximumFractionDigits: 2 })}`, attr: { 'data-sort': $data.ultraballMagicBall }"></td>
+                    </tr>
+                    <!-- /ko -->
+                </tbody>
+            </table>
+        </div>
+        <p>Refresh if the weather in the regions above are out of sync with your game.</p>
+    </div>
+    <!-- /ko -->
+</div>

--- a/pages/Catch Type Quests/overview.html
+++ b/pages/Catch Type Quests/overview.html
@@ -1,0 +1,7 @@
+<div style="max-width: 900px;">
+    <!-- ko foreach: GameHelper.enumNumbers(PokemonType).filter(t => t >= 0) -->
+    <span class="type-icon badge m-1" data-bind="style:{ background: GameConstants.TypeColor[$data] }">
+        <a style="text-decoration: none; font-size: 0.875rem; color: #f5f5f5;" data-bind="text: PokemonType[$data], attr: { href: `#!Catch Type Quests/${PokemonType[$data]}` }"></a>
+    </span>
+    <!-- /ko -->
+</div>

--- a/pages/Gems/main.html
+++ b/pages/Gems/main.html
@@ -1,12 +1,12 @@
 <div>
     <!-- ko ifnot: PokemonType[Wiki.pageName()] >= 0 -->
-        <h3>Gem type not found...</h3>
+    <h3>Gem type not found...</h3>
     <!-- /ko -->
     <!-- ko if: PokemonType[Wiki.pageName()] >= 0 -->
     <div data-bind="with: Wiki.pageName()">
         <img data-bind="attr: {src: './pokeclicker/docs/' + Gems.image(PokemonType[$data])}"/>
-
-        <h3>Best locations</h3>
+        <h3 data-bind="text: `Best ${$data} Gem farming locations`"></h3>
+        <p>The top two locations from each Region are listed below, if they exist.</p>
         <p>Pokémon that appear during certain weather or other special conditions are not included in the route calculation.</p>
         <div class="table-responsive">
             <table class="table table-hover table-striped table-bordered">
@@ -15,48 +15,23 @@
                         <th>Region</th>
                         <th>Battle Type</th>
                         <th>Location</th>
+                        <th style="text-align: right;">Maximum HP</th>
+                        <th style="width: 20%; text-align: right;">Average Gems Per Pokémon</th>
                     </tr>
                 </thead>
-                <tbody data-bind="foreach: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none)">
+                <tbody data-bind="foreach: { data: GameHelper.enumNumbers(GameConstants.Region).filter((r) => r <= GameConstants.MAX_AVAILABLE_REGION && r != GameConstants.Region.none), as: 'region' }">
+                    <!-- ko foreach: Wiki.gems.bestGemsPerRegion(region, $parent) -->
                     <tr>
-                        <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[$data])" rowspan="2" class="align-middle"></td>
-                        <td>Gym</td>
-                        <td data-bind="text: (() => {
-                            var regionGyms = GameConstants.RegionGyms[$data].filter((g) => !g.includes('Trial'));
-                            var amountPerGym = regionGyms
-                                .map((g) => {
-                                    var totalMons = GymList[g].pokemons.length;
-                                    var totalOfType = GymList[g].pokemons.filter((p) => PokemonHelper.getPokemonByName(p.name).type1 == PokemonType[$parent] || PokemonHelper.getPokemonByName(p.name).type2 == PokemonType[$parent]).length;
-                                    return Math.round(totalOfType / totalMons * 100);
-                                });
-                            var max = Math.max(...amountPerGym);
-                            if (!max) {
-                                return 'No gym with this gem';
-                            }
-                            return max + '% at ' + regionGyms[amountPerGym.indexOf(max)];
-                        })()
-                        "></td>
+                        <td data-bind="text: GameConstants.camelCaseToString(GameConstants.Region[region]), attr: { 'data-sort': region }"></td>
+                        <td data-bind="text: $data.battleType"></td>
+                        <td><a style="text-decoration: none;" data-bind="text: $data.name, attr: { href: `#!${$data.battleType}s/${$data.name}` }"></a></td>
+                        <td style="text-align: right;" data-bind="text: `${$data.maxHealth.toLocaleString()} ❤️`, attr: { 'data-sort' : $data.maxHealth }"></td>
+                        <td style="text-align: right;" data-bind="attr: { 'data-sort': $data.gemsPerEncounter }">
+                            <ko data-bind="text: $data.gemsPerEncounter.toFixed(2)"></ko>
+                            <img style="margin: -6px 0" data-bind="attr: { src: './pokeclicker/docs/' + Gems.image(PokemonType[Wiki.pageName()]) }"/>
+                        </td>
                     </tr>
-                    <tr>
-                        <td>Route</td>
-                        <td data-bind="text: (() => {
-                            var regionRoutes = Routes.regionRoutes.filter((r) => r.region == $data);
-                            var amountPerRoute = regionRoutes
-                                .map((r) => {
-                                    var totalMons = r.pokemon.land.length+r.pokemon.water.length+r.pokemon.headbutt.length;
-                                    var totalOfType = r.pokemon.land.filter((p) => PokemonHelper.getPokemonByName(p).type1 == PokemonType[$parent] || PokemonHelper.getPokemonByName(p).type2 == PokemonType[$parent]).length +
-                                                    r.pokemon.water.filter((p) => PokemonHelper.getPokemonByName(p).type1 == PokemonType[$parent] || PokemonHelper.getPokemonByName(p).type2 == PokemonType[$parent]).length +
-                                                    r.pokemon.headbutt.filter((p) => PokemonHelper.getPokemonByName(p).type1 == PokemonType[$parent] || PokemonHelper.getPokemonByName(p).type2 == PokemonType[$parent]).length;
-                                    return Math.round(totalOfType / totalMons * 100);
-                                });
-                            var max = Math.max(...amountPerRoute);
-                            if (!max) {
-                                return 'No route with this gem';
-                            }
-                            return max + '% at ' + regionRoutes[amountPerRoute.indexOf(max)].routeName;
-                        })()
-                        "></td>
-                    </tr>
+                    <!-- /ko -->
                 </tbody>
             </table>
         </div>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -22,8 +22,8 @@ themes.options.sort((a, b) => (a.text).localeCompare(b.text));
 // Suppress game notifications
 Notifier.notify = () => {};
 
-// Ensure weather never satisfies requirements so they are always shown
-Weather.currentWeather = () => -1;
+// Ensure requirements are never satisfied so they are always shown
+Requirement.prototype.isCompleted = () => false;
 
 // Not sure why but this was causing an error on load after the v0.10.22 update
 SortModules = () => {};
@@ -78,6 +78,7 @@ GemDeals.generateDeals();
 ShardDeal.generateDeals();
 GenericDeal.generateDeals();
 SafariPokemonList.generateSafariLists(); // This needs to be after anything that generates shopmon due to Friend Safari calcs
+Weather.generateWeather(now);
 
 // Farm Simulator
 App.game.farming.plotList.forEach((p) => p.isUnlocked = true); // All plots unlocked

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -20,6 +20,7 @@ window.Wiki = {
   shopMon: require('./pages/shopMon'),
   dungeonTokens: require('./pages/dungeonTokens'),
   oakItems: require('./pages/oakItems'),
+  gems: require('./pages/gems'),
   getDealChains: require('./pages/dealChains').getDealChains,
   ...require('./navigation'),
 }

--- a/scripts/pages/dungeonTokens.js
+++ b/scripts/pages/dungeonTokens.js
@@ -51,7 +51,7 @@ const highestRoute = (region, weather) => {
         const GBMB = (DT* (catchChanceAV+.15))/(2);
         const UB = (DT* (catchChanceAV+.1))/(1.75)
         const UBMB = (DT* (catchChanceAV+.2))/(1.75);
-        routeArr.push( [Routes.getRoute(region,route.number).routeName, DT.toLocaleString(), +(PB). toFixed(2), +(PBMB). toFixed(2), +(GB). toFixed(2), +(GBMB). toFixed(2), +(UB). toFixed(2), +(UBMB). toFixed(2)] );
+        routeArr.push([Routes.getRoute(region,route.number).routeName, DT.toLocaleString(), +(PB).toFixed(2), +(PBMB).toFixed(2), +(GB).toFixed(2), +(GBMB).toFixed(2), +(UB).toFixed(2), +(UBMB).toFixed(2)])
     })
 
     var highestPB = routeArr.reduce((max, dt) => {

--- a/scripts/pages/gems.js
+++ b/scripts/pages/gems.js
@@ -1,0 +1,138 @@
+// routeAvgHp copied from PokemonFactory.generateWildPokemon
+const routeAvgHp = (region, route) => {
+    const poke = [...new Set(Object.values(Routes.getRoute(region, route).pokemon).flat().map(p => p.pokemon ?? p).flat())];
+    const total = poke.map(p => pokemonMap[p].base.hitpoints).reduce((s, a) => s + a, 0);
+    return total / poke.length;
+};
+
+const getStandardEncounters = (route) => {
+    return Object.values(route.pokemon).flat().filter((p) => typeof p === 'string');
+}
+
+const maxRouteHp = (regionRoutes, routeName) => {
+    const route = regionRoutes.find((r) => r.routeName === routeName);
+    const allMons = getStandardEncounters(route);
+    const maxHpStat = Math.max(...allMons.map((p) => PokemonHelper.getPokemonByName(p).hitpoints));
+    return Math.round(PokemonFactory.routeHealth(route.number, route.region) * (0.9 + (maxHpStat / routeAvgHp(route.region, route.number)) / 10));
+}
+
+const maxGymHp = (gymName) => {
+    return Math.max(...GymList[gymName].pokemons.map((p) => p.maxHealth));
+}
+
+const gemsPerPokemon = (pokemonName, gemType) => {
+    const pokemon = PokemonHelper.getPokemonByName(pokemonName);
+    const targetType = PokemonType[gemType];
+    if (pokemon.type2 === PokemonType.None) {
+        return pokemon.type1 === targetType ? 2 : 0;
+    } else {
+        return (pokemon.type1 === targetType || pokemon.type2 === targetType) ? 1 : 0;
+    }
+}
+
+const gemsPerGymEncounter = (gymName, gemType) => {
+    const gym = GymList[gymName];
+    const totalMons = gym.pokemons.length;
+    const totalGemsOfType = gym.pokemons.reduce((acc, p) => acc + 5 * gemsPerPokemon(p.name, gemType), 0);
+    return totalGemsOfType / totalMons;
+}
+
+const gemsPerRouteEncounter = (route, gemType) => {
+    const allMons = getStandardEncounters(route);
+    const totalMons = allMons.length;
+    const totalGemsOfType = allMons.reduce((acc, p) => acc + gemsPerPokemon(p, gemType), 0);
+    return totalGemsOfType / totalMons;
+}
+
+const bestGemsPerRegion = (region, gemType) => {
+    const regionRoutes = Routes.regionRoutes.filter((r) => r.region == region);
+    const allRouteGems = regionRoutes.map((route) => ({
+        battleType: "Route",
+        name: route.routeName,
+        gemsPerEncounter: gemsPerRouteEncounter(route, gemType),
+    }));
+
+    const regionGyms = GameConstants.RegionGyms[region].filter((g) => !g.includes('Trial'));
+    const allGymGems = regionGyms.map((gym) => ({
+        battleType: "Gym",
+        name: gym,
+        gemsPerEncounter: gemsPerGymEncounter(gym, gemType),
+    }));
+
+    return allRouteGems.concat(allGymGems)
+        .filter((battle) => battle.gemsPerEncounter > 0)
+        .sort((a, b) => b.gemsPerEncounter - a.gemsPerEncounter)
+        .splice(0, 2)
+        .map((gemData) => {
+            gemData.maxHealth = gemData.battleType === "Route" ? maxRouteHp(regionRoutes, gemData.name) : maxGymHp(gemData.name);
+            return gemData;
+        });
+}
+
+const bestCaptureRoutesPerRegion = (region, type) => {
+    const regionRoutes = Routes.regionRoutes.filter((r) => r.region == region);
+    const currentWeather = Weather.regionalWeather[region]();
+    const today = GameHelper.today().getDay();
+    const allRegionRoutesTypeCatchChance = regionRoutes.map((route) => {
+        const normalEncounters = getStandardEncounters(route);
+        const specialEncounters = route.pokemon.special.flatMap((special) => {
+            if (special.req instanceof OneFromManyRequirement || special.req instanceof SpecialEventRandomRequirement) {
+                // OneFromMany is Santa Jynx only
+                return [];
+            }
+            if (special.req instanceof WeatherRequirement) {
+                return special.req.weather.includes(currentWeather) ? special.pokemon : [];
+            }
+            if (special.req instanceof DayOfWeekRequirement) {
+                return special.req.DayOfWeekNum === today ? special.pokemon : [];
+            }
+            if (special.req instanceof MultiRequirement) {
+                // This might not cover all permutations of requirements
+                if (special.req.requirements.find((req) => req instanceof SpecialEventRequirement)) return [];
+                const weatherReq = special.req.requirements.find((req) => req instanceof WeatherRequirement);
+                if (weatherReq) return weatherReq.weather.includes(currentWeather) ? special.pokemon : [];
+                const dayReq = special.req.requirements.find((req) => req instanceof DayOfWeekRequirement);
+                if (dayReq) return dayReq.DayOfWeekNum === today ? special.pokemon : [];
+            }
+            return special.pokemon
+        });
+
+        const allEncounters = normalEncounters.concat(specialEncounters);
+        const typeCatchChances = allEncounters.map((p) => {
+            const pokemon = PokemonHelper.getPokemonByName(p);
+            return (pokemon.type1 === type || pokemon.type2 === type) ? PokemonFactory.catchRateHelper(pokemon.catchRate, true) : 0;
+        });
+        return {
+            route: route,
+            catchChances: typeCatchChances,
+        };
+    });
+
+    const allRoutesWithType = allRegionRoutesTypeCatchChance.filter((route) => route.catchChances.some((chance) => chance > 0));
+    const allRoutesWithCatchBonuses = allRoutesWithType.map((route) => {
+        const encounters = route.catchChances.length;
+        return {
+            route: route.route,
+            pokeball: route.catchChances.reduce((a, b) => a + b, 0) / encounters,
+            ultraball: route.catchChances.map((chance) => chance > 0 ? chance + 10 : chance).reduce((a, b) => a + b, 0) / encounters,
+            ultraballMagicBall: route.catchChances.map((chance) => chance > 0 ? chance + 20 : chance).reduce((a, b) => a + b, 0) / encounters,
+        }
+    });
+    return allRoutesWithCatchBonuses
+        .sort((a, b) => b.ultraballMagicBall - a.ultraballMagicBall)
+        .splice(0, 2)
+        .map((route) => {
+            return {
+                ...route,
+                weather: currentWeather,
+                today: today,
+                maxHealth: maxRouteHp(regionRoutes, route.route.routeName),
+            }
+        });
+}
+
+
+module.exports = {
+    bestGemsPerRegion,
+    bestCaptureRoutesPerRegion,
+}

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -60,6 +60,11 @@ const searchOptions = [
     type: 'Gems',
     page: t,
   })),
+  ...GameHelper.enumStrings(PokemonType).filter(t => t != 'None').map(t => ({
+    display: `${t} Catch Type Quests`,
+    type: 'Catch Type Quests',
+    page: t,
+  })),
   // Berries
   {
     display: 'Berries',

--- a/styles.css
+++ b/styles.css
@@ -450,3 +450,10 @@ td.tight {
 .obtain-methods .accordion-button img {
   padding-right: 10px;
 }
+
+.type-icon {
+  line-height: normal;
+  text-shadow: 0px 0px 1px black, 0px 0px 1px black, 0px 0px 1px black, 0px 0px 2px black, 0px 0px 2px black, 0px 0px 3px black;
+  text-transform: uppercase;
+  color: #f5f5f5;
+}

--- a/templates/pokemon-summary.html
+++ b/templates/pokemon-summary.html
@@ -84,7 +84,7 @@
             <td>Type(s)</td>
             <td>
                 <!-- ko foreach: $data.type -->
-                    <span class="badge" data-bind="text: PokemonType[$data], style:{ background: GameConstants.TypeColor[$data] }"></span>
+                    <span class="badge type-icon" data-bind="text: PokemonType[$data], style:{ background: GameConstants.TypeColor[$data] }"></span>
                 <!-- /ko -->
             </td>
         </tr>


### PR DESCRIPTION
Gem Pages have been updated for the monotype gem buff, made the information more useful (% means nothing when different mons/encounter types give different numbers of gems), and return the two best locations per region, rather than 1 gym + 1 route (as routes are generally terrible)

![image](https://github.com/user-attachments/assets/af5b0d16-4c76-487d-8807-07b19c63be20)

Gem pages were often used as a proxy for locating specific types for a type-catch quest, however they were poor due to not taking into consideration catch chances, added a tailor-made page for this use:

![image](https://github.com/user-attachments/assets/abdc0f9b-a0a1-41c9-8025-428591cfdc1c)

While there are some similarities with the Dungeon Tokens table, I went for simplicity of fetching the current day/weather conditions and calculating from there, and also chose three key datapoints for the catch chance modifiers rather than listing every combination

Finally, added the requirement override which makes all requirements show as incomplete, so the various "less than" requirements that are completed by default now show:
![image](https://github.com/user-attachments/assets/73f8fdaf-61fd-4f0b-9740-36fdb10612a3)
