### PR TITLE
Fix gym typeahead dupes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -79855,6 +79855,7 @@ const excludedItemTypes = [
   'BuyOakItem',
 ];
 
+// Load gyms and handle duplicate leader names
 const gymEntries = Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
   display: gym.leaderName,
   type: 'Gyms',
@@ -79869,7 +79870,13 @@ if (duplicateGymDisplayNames.size) {
   for (let entry of gymEntries) {
     if (duplicateGymDisplayNames.has(entry.display)) {
       const gymInstance = GymList[entry.page];
-      entry.display = `${entry.display} (${gymInstance.displayName ?? entry.page})`;
+
+      // Elite check mirrors AchievementHandler.initialize
+      const elite = entry.page.includes('Elite') || entry.page.includes('Champion') || entry.page.includes('Supreme');
+
+      const gymName = gymInstance.displayName ?? `${entry.page}${!elite ? ' Gym' : ''}`;
+
+      entry.display = `${entry.display} (${gymName})`;
     }
   }
 }

--- a/bundle.js
+++ b/bundle.js
@@ -79855,6 +79855,25 @@ const excludedItemTypes = [
   'BuyOakItem',
 ];
 
+const gymEntries = Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
+  display: gym.leaderName,
+  type: 'Gyms',
+  page: key,
+}));
+
+const duplicateGymDisplayNames = new Set(gymEntries.filter((entry, idx, list) => {
+  return list.findLastIndex(innerEntry => innerEntry.display === entry.display) !== idx;
+}).map(entry => entry.display));
+
+if (duplicateGymDisplayNames.size) {
+  for (let entry of gymEntries) {
+    if (duplicateGymDisplayNames.has(entry.display)) {
+      const gymInstance = GymList[entry.page];
+      entry.display = `${entry.display} (${gymInstance.displayName ?? entry.page})`;
+    }
+  }
+}
+
 const searchOptions = [
   {
     display: 'Home',
@@ -80038,11 +80057,7 @@ const searchOptions = [
     type: 'Gyms',
     page: '',
   },
-  ...Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
-    display: gym.leaderName,
-    type: 'Gyms',
-    page: key,
-  })),
+  ...gymEntries,
   // Routes
   {
     display: 'Routes',

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -8,6 +8,7 @@ const excludedItemTypes = [
   'BuyOakItem',
 ];
 
+// Load gyms and handle duplicate leader names
 const gymEntries = Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
   display: gym.leaderName,
   type: 'Gyms',
@@ -22,7 +23,13 @@ if (duplicateGymDisplayNames.size) {
   for (let entry of gymEntries) {
     if (duplicateGymDisplayNames.has(entry.display)) {
       const gymInstance = GymList[entry.page];
-      entry.display = `${entry.display} (${gymInstance.displayName ?? entry.page})`;
+
+      // Elite check mirrors AchievementHandler.initialize
+      const elite = entry.page.includes('Elite') || entry.page.includes('Champion') || entry.page.includes('Supreme');
+
+      const gymName = gymInstance.displayName ?? `${entry.page}${!elite ? ' Gym' : ''}`;
+
+      entry.display = `${entry.display} (${gymName})`;
     }
   }
 }

--- a/scripts/typeahead.js
+++ b/scripts/typeahead.js
@@ -8,6 +8,25 @@ const excludedItemTypes = [
   'BuyOakItem',
 ];
 
+const gymEntries = Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
+  display: gym.leaderName,
+  type: 'Gyms',
+  page: key,
+}));
+
+const duplicateGymDisplayNames = new Set(gymEntries.filter((entry, idx, list) => {
+  return list.findLastIndex(innerEntry => innerEntry.display === entry.display) !== idx;
+}).map(entry => entry.display));
+
+if (duplicateGymDisplayNames.size) {
+  for (let entry of gymEntries) {
+    if (duplicateGymDisplayNames.has(entry.display)) {
+      const gymInstance = GymList[entry.page];
+      entry.display = `${entry.display} (${gymInstance.displayName ?? entry.page})`;
+    }
+  }
+}
+
 const searchOptions = [
   {
     display: 'Home',
@@ -191,11 +210,7 @@ const searchOptions = [
     type: 'Gyms',
     page: '',
   },
-  ...Object.entries(GymList).filter(([key, gym]) => GameConstants.getGymRegion(gym) <= GameConstants.MAX_AVAILABLE_REGION).map(([key, gym]) => ({
-    display: gym.leaderName,
-    type: 'Gyms',
-    page: key,
-  })),
+  ...gymEntries,
   // Routes
   {
     display: 'Routes',


### PR DESCRIPTION
Added display name or gym location/internal ID to gyms with non-unique leader names.
This fixes `Olivia (Gyms) (Gyms)`.

Feel free to make changes for code clarity; I made this at 5am.