### PR TITLE
Use a working cdn for datatables

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>
 
         <!--Datatables-->
-        <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.css"/>
-        <script type="text/javascript" src="https://cdn.datatables.net/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.js"></script>
-        <script type="text/javascript" src="https://cdn.datatables.net/plug-ins/1.13.6/api/order.neutral().min.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://datatables-cdn.com/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.css"/>
+        <script type="text/javascript" src="https://datatables-cdn.com/v/bs5/dt-1.13.1/cr-1.6.1/datatables.min.js"></script>
+        <script type="text/javascript" src="https://datatables-cdn.com/plug-ins/1.13.6/api/order.neutral().min.js"></script>
 
         <!--Simple Markdown Editor-->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">


### PR DESCRIPTION
Switch to alternate cdn for datatables, the old one is down - https://github.com/DataTables/DataTablesSrc/issues/354#issuecomment-3131409407

The datatables maintainer says this cdn will be maintained indefinitely.