### PR TITLE
Update QuestLInes main page with quest steps default description

### DIFF
--- a/pages/Quest Lines/main.html
+++ b/pages/Quest Lines/main.html
@@ -1,6 +1,6 @@
 <div>
     <!-- ko ifnot: App.game.quests.questLines().find((q) => q.name == Wiki.pageName()) -->
-        <h3>Quest not found...</h3>
+    <h3>Quest not found...</h3>
     <!-- /ko -->
     <!-- ko if: App.game.quests.questLines().find((q) => q.name == Wiki.pageName()) -->
     <div data-bind="with: App.game.quests.questLines().find((q) => q.name == Wiki.pageName())">
@@ -12,12 +12,31 @@
             <li class="list-group-item">
                 <span data-bind="text: $data.description"></span>
                 <ul data-bind="foreach: $data.quests">
+                    <!-- ko if: $data.defaultDescription === 'Generic Quest Description. This should be overriden.'-->
                     <li data-bind="text: $data.description"></li>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $data.defaultDescription === 'Generic Quest Description. This should be overriden.'-->
+                    <li data-bind="text: $data.description"></li>
+                    <ul>
+                        <li data-bind="text: $data.defaultDescription"></li>
+                    </ul>
+                    <!-- /ko -->
+
                 </ul>
             </li>
             <!-- /ko -->
             <!-- ko ifnot: $data.quests -->
+            <!-- ko if: $data.defaultDescription === 'Generic Quest Description. This should be overriden.'-->
             <li class="list-group-item" data-bind="text: $data.description"></li>
+            <!-- /ko -->
+            <!-- ko ifnot: $data.defaultDescription === 'Generic Quest Description. This should be overriden.'-->
+            <li class="list-group-item">
+                <span data-bind="text: $data.description"></span>
+                <ul>
+                    <li data-bind="text: $data.defaultDescription"></li>
+                </ul>
+            </li>
+            <!-- /ko -->
             <!-- /ko -->
         </ol>
     </div>


### PR DESCRIPTION
Updated QuestLInes main page with quest steps default description. This will provide increased readability and information regarding the Quest steps.

<img width="914" height="532" alt="image" src="https://github.com/user-attachments/assets/a7086000-4fad-441f-8224-9238b995f4a9" />
