### PR TITLE
Safari catch table

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
         <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 
-        <link href="./styles.css?t=1780956343909" rel="stylesheet">
+        <link href="./styles.css?t=1782598073705" rel="stylesheet">
 
     </head>
     <body class="no-select">
@@ -252,6 +252,6 @@
         </template>
 
         <!-- Main wiki script -->
-        <script src="bundle.js?t=1780956343909"></script>
+        <script src="bundle.js?t=1782598073705"></script>
     </body>
 </html>

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -71,55 +71,55 @@
                                     <td data-bind="text: ($data.catchRate / 6 ).toFixed(2)  + '%'"></td>
                                     <td data-bind="text: (() =>
                                         {
-                                        const level = Math.max(0, Math.min(safariLevel(),Safari.maxSafariLevel));
-                                        const safariPoke = new SafariPokemon($data.name);
-                                        safariPoke.levelModifier = (level - 1) / 50;
+                                            const level = Math.max(0, Math.min(safariLevel(),Safari.maxSafariLevel));
+                                            const safariPoke = new SafariPokemon($data.name);
+                                            safariPoke.levelModifier = (level - 1) / 50;
 
 
-                                        function catchFactor(eating, angry, bait){
-                                        let catchF = safariPoke.baseCatchFactor + magicBallBonus() + (safariPoke.levelModifier * 10);
-                                        if (eating > 0) {
-                                        catchF /= 2 - safariPoke.levelModifier;
-                                        }
-                                        if (angry > 0) {
-                                        catchF *= 2 + safariPoke.levelModifier;
-                                        }
-                                        if (bait === BaitType.Nanab) {
-                                        catchF *= 1.5 + safariPoke.levelModifier;
-                                        }
+                                            function catchFactor(eating, angry, bait){
+                                                let catchF = safariPoke.baseCatchFactor + magicBallBonus() + (safariPoke.levelModifier * 10);
+                                                if (eating > 0) {
+                                                    catchF /= 2 - safariPoke.levelModifier;
+                                                    }
+                                                    if (angry > 0) {
+                                                    catchF *= 2 + safariPoke.levelModifier;
+                                                    }
+                                                    if (bait === BaitType.Nanab) {
+                                                    catchF *= 1.5 + safariPoke.levelModifier;
+                                                    }
 
-                                        return Math.min(100, catchF);
-                                        }
+                                                    return Math.min(100, catchF);
+                                            }
 
-                                        function escapeFactor(eating, angry, bait){
-                                        let escapeF = safariPoke.baseEscapeFactor;
-                                        if (eating > 0) {
-                                        escapeF /= 4 + safariPoke.levelModifier;
-                                        }
-                                        if (angry > 0) {
-                                        escapeF *= 2 - safariPoke.levelModifier;
-                                        }
-                                        if (bait === BaitType.Razz) {
-                                        escapeF /= 1.5 + safariPoke.levelModifier;
-                                        }
+                                            function escapeFactor(eating, angry, bait){
+                                                let escapeF = safariPoke.baseEscapeFactor;
+                                                    if (eating > 0) {
+                                                    escapeF /= 4 + safariPoke.levelModifier;
+                                                    }
+                                                    if (angry > 0) {
+                                                    escapeF *= 2 - safariPoke.levelModifier;
+                                                    }
+                                                    if (bait === BaitType.Razz) {
+                                                    escapeF /= 1.5 + safariPoke.levelModifier;
+                                                }
 
-                                        return (1-(escapeF/100));
-                                        }
+                                                return (1-(escapeF/100));
+                                            }
 
-                                        const catchMethods = {
-                                        Bait : escapeFactor(1,0,0) * catchFactor(1,0,0),
-                                        Rock : escapeFactor(0,1,0) * catchFactor(0,1,0),
-                                        BaitRock : escapeFactor(1,0,0) * escapeFactor(0,1,0) * catchFactor(0,1,0),
-                                        Nanab : escapeFactor(1,0,BaitType.Nanab) * catchFactor(1,0,BaitType.Nanab),
-                                        NanabRock : escapeFactor(1,0,BaitType.Nanab) * escapeFactor(0,1,0) * catchFactor(0,1,BaitType.Nanab),
-                                        Razz : escapeFactor(1,0,BaitType.Razz)  * catchFactor(1,0,BaitType.Razz),
-                                        RazzRock : escapeFactor(1,0,BaitType.Razz) * escapeFactor(0,1,BaitType.Razz) * catchFactor(0,1,BaitType.Razz),
-                                        };
+                                            const catchMethods = {
+                                            Bait : escapeFactor(1,0,0) * catchFactor(1,0,0),
+                                            Rock : escapeFactor(0,1,0) * catchFactor(0,1,0),
+                                            BaitRock : escapeFactor(1,0,0) * escapeFactor(0,1,0) * catchFactor(0,1,0),
+                                            Nanab : escapeFactor(1,0,BaitType.Nanab) * catchFactor(1,0,BaitType.Nanab),
+                                            NanabRock : escapeFactor(1,0,BaitType.Nanab) * escapeFactor(0,1,0) * catchFactor(0,1,BaitType.Nanab),
+                                            Razz : escapeFactor(1,0,BaitType.Razz)  * catchFactor(1,0,BaitType.Razz),
+                                            RazzRock : escapeFactor(1,0,BaitType.Razz) * escapeFactor(0,1,BaitType.Razz) * catchFactor(0,1,BaitType.Razz),
+                                            };
 
-                                        const largestVariable = Object.keys(catchMethods).reduce((x, y) => catchMethods[x] > catchMethods[y] ? x : y);
-                                        const methodText = largestVariable.replace('Rock', ' Rock');
+                                            const largestVariable = Object.keys(catchMethods).reduce((x, y) => catchMethods[x] > catchMethods[y] ? x : y);
+                                            const methodText = largestVariable.replace('Rock', ' Rock');
 
-                                        return (`${methodText} with ${catchMethods[largestVariable].toFixed(2)}% chance on the first ball`).toLocaleString();
+                                            return (`${methodText} with ${catchMethods[largestVariable].toFixed(2)}% chance on the first ball`).toLocaleString();
                                         })()">
                                     </td>
                                 </tr>

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -71,33 +71,49 @@
                                     <td data-bind="text: ($data.catchRate / 6 ).toFixed(2)  + '%'"></td>
                                     <td data-bind="text: (() =>
                                         {
-                                        const level = safariLevel() < 0 ? 1 : safariLevel() > 40 ? 40 : safariLevel();
-                                        const multiplier = ((level - 1) /  50);
-                                        const baseEscape = 30;
-                                        const basecatchRate = ($data.catchRate / 6 ) + magicBallBonus() + (multiplier * 10);
-
-                                        function eatingCatch (catchChance) { return (catchChance / (2 - multiplier)) > 100 ? 100 : (catchChance / (2 - multiplier)); }
-                                        function angryCatch (catchChance)  { return (catchChance * (2 + multiplier)) > 100 ? 100 :  (catchChance * (2 + multiplier)); }
-                                        function nanabCatch (catchChance)  { return (catchChance * (1.5 + multiplier)) > 100 ? 100 : (catchChance * (1.5 + multiplier)); }
-                                        function eatingEscape (escapeChance) { return (escapeChance / (4 + multiplier));}
-                                        function angryEscape (escapeChance) { return (escapeChance * (2 - multiplier));}
-                                        function razzEscape (escapeChance) { return (escapeChance / (1.5 + multiplier));}
+                                        const level = Math.max(0, Math.min(safariLevel(),Safari.maxSafariLevel));
+                                        const safariPoke = new SafariPokemon($data.name);
+                                        safariPoke.levelModifier = (level - 1) / 50;
 
 
-                                        const eatingEscapeChance = 1-(eatingEscape(baseEscape) / 100);
-                                        const angryEscapeChance = 1-(angryEscape(baseEscape) / 100);
-                                        const razzEatingEscapeChance = 1-(razzEscape(eatingEscape(baseEscape)) / 100);
-                                        const razzAngryEscapeChance = 1-(razzEscape(angryEscape(baseEscape)) / 100);
+                                        function catchFactor(eating, angry, bait){
+                                        let catchF = safariPoke.baseCatchFactor + magicBallBonus() + (safariPoke.levelModifier * 10);
+                                        if (eating > 0) {
+                                        catchF /= 2 - safariPoke.levelModifier;
+                                        }
+                                        if (angry > 0) {
+                                        catchF *= 2 + safariPoke.levelModifier;
+                                        }
+                                        if (bait === BaitType.Nanab) {
+                                        catchF *= 1.5 + safariPoke.levelModifier;
+                                        }
 
+                                        return Math.min(100, catchF);
+                                        }
+
+                                        function escapeFactor(eating, angry, bait){
+                                        let escapeF = safariPoke.baseEscapeFactor;
+                                        if (eating > 0) {
+                                        escapeF /= 4 + safariPoke.levelModifier;
+                                        }
+                                        if (angry > 0) {
+                                        escapeF *= 2 - safariPoke.levelModifier;
+                                        }
+                                        if (bait === BaitType.Razz) {
+                                        escapeF /= 1.5 + safariPoke.levelModifier;
+                                        }
+
+                                        return (1-(escapeF/100));
+                                        }
 
                                         const catchMethods = {
-                                        Bait : eatingEscapeChance  * eatingCatch(basecatchRate),
-                                        Rock : angryEscapeChance * angryCatch(basecatchRate),
-                                        BaitRock : eatingEscapeChance * angryEscapeChance * angryCatch(basecatchRate),
-                                        Nanab : eatingEscapeChance  * nanabCatch(eatingCatch(basecatchRate)),
-                                        NanabRock : eatingEscapeChance  * angryEscapeChance *  nanabCatch(angryCatch(basecatchRate)),
-                                        Razz : razzEatingEscapeChance  *  eatingCatch(basecatchRate),
-                                        RazzRock : razzEatingEscapeChance * razzAngryEscapeChance * angryCatch(basecatchRate)
+                                        Bait : escapeFactor(1,0,0) * catchFactor(1,0,0),
+                                        Rock : escapeFactor(0,1,0) * catchFactor(0,1,0),
+                                        BaitRock : escapeFactor(1,0,0) * escapeFactor(0,1,0) * catchFactor(0,1,0),
+                                        Nanab : escapeFactor(1,0,BaitType.Nanab) * catchFactor(1,0,BaitType.Nanab),
+                                        NanabRock : escapeFactor(1,0,BaitType.Nanab) * escapeFactor(0,1,0) * catchFactor(0,1,BaitType.Nanab),
+                                        Razz : escapeFactor(1,0,BaitType.Razz)  * catchFactor(1,0,BaitType.Razz),
+                                        RazzRock : escapeFactor(1,0,BaitType.Razz) * escapeFactor(0,1,BaitType.Razz) * catchFactor(0,1,BaitType.Razz),
                                         };
 
                                         const largestVariable = Object.keys(catchMethods).reduce((x, y) => catchMethods[x] > catchMethods[y] ? x : y);

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -1,0 +1,48 @@
+<div>
+    <h3>Safair Catch Rate</h3>
+    <table class="table table-hover table-striped table-bordered no-data-tables" data-bind="with: { stage: ko.observable(BattleFrontierRunner.stage.peek()), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
+        <thead class="thead-dark">
+            <tr>
+                <th>Level</th>
+                <th>
+                    <input type="number" min="1" step="1" max="40" data-bind="event: { input: (data, e) => {
+                    BattleFrontierRunner.stage = ko.observable(+e.target.value);
+                    BattleFrontierBattle.generateNewEnemy();
+                    $data.stage(+e.target.value);
+                    $data.enemyPokemon(BattleFrontierBattle.enemyPokemon());
+                } }, value: $data.stage" />
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>HP per Pokémon</td>
+                <td data-bind="text: $data.enemyPokemon().health().toLocaleString('en-US')"></td>
+            </tr>
+            <tr>
+                <td>HP in Total</td>
+                <td data-bind="text: ($data.enemyPokemon().health() * 3).toLocaleString('en-US')"></td>
+            </tr>
+            <tr>
+                <td>Damage required (after types)</td>
+                <td data-bind="text: Math.ceil($data.enemyPokemon().health() * 3 / 30).toLocaleString('en-US')"></td>
+            </tr>
+            <tr>
+                <td>Battle Points</td>
+                <td data-bind="text: Math.round($data.stage() * Math.max($data.stage() / 100, 1)).toLocaleString()"></td>
+            </tr>
+            <tr>
+                <td>Pokédollars</td>
+                <td data-bind="text: ($data.stage() * 100 * Math.max($data.stage() / 100, 1)).toLocaleString()"></td>
+            </tr>
+            <tr>
+                <td>Egg Steps per Pokémon</td>
+                <td data-bind="text: +Math.sqrt($data.stage()).toFixed(2)"></td>
+            </tr>
+            <tr>
+                <td>Gems per Pokémon</td>
+                <td data-bind="text: Math.ceil($data.stage() / 80).toLocaleString()"></td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -60,8 +60,8 @@
                                 </tr>
                             </thead>
                             <tbody data-bind="foreach: pokemonList.filter((p) =>
-                                ($data.value == 5 ? (PokemonLocations.isObtainableAndNotEvable(p.name)
-                                && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION) || SafariPokemonList.list[GameConstants.Region.kalos]().find(x =>x.name == p.name) : PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]!== undefined && (Object.keys(PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]) == $data.value || Object.keys(PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]).includes(String($data.value))  )  ) ) ">
+                                ($data.value == 5 ? (PokemonLocations.isObtainableAndNotEvable(p.name) && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION) || SafariPokemonList.list[GameConstants.Region.kalos]().find(x =>x.name == p.name) 
+                                : PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]!== undefined && Object.keys(PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]).includes(String($data.value))) ) ">
                                 <tr class="align-middle">
                                     <td data-bind="text: `#${Math.floor($data.id).toString().padStart(3, '0')}`, attr: { 'data-sort': $data.id }"></td>
                                     <td>

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -1,48 +1,123 @@
-<div>
-    <h3>Safair Catch Rate</h3>
-    <table class="table table-hover table-striped table-bordered no-data-tables" data-bind="with: { stage: ko.observable(BattleFrontierRunner.stage.peek()), enemyPokemon: ko.observable(BattleFrontierBattle.enemyPokemon.peek()) }">
-        <thead class="thead-dark">
-            <tr>
-                <th>Level</th>
-                <th>
-                    <input type="number" min="1" step="1" max="40" data-bind="event: { input: (data, e) => {
-                    BattleFrontierRunner.stage = ko.observable(+e.target.value);
-                    BattleFrontierBattle.generateNewEnemy();
-                    $data.stage(+e.target.value);
-                    $data.enemyPokemon(BattleFrontierBattle.enemyPokemon());
-                } }, value: $data.stage" />
-                </th>
-            </tr>
-        </thead>
+<!-- ko let: {
+    magicBallBonusList: App.game.oakItems.itemList[OakItemType.Magic_Ball].bonusList.map((b, i) => ({ level: i, bonus: b })),
+} -->
+<!-- ko let: {
+    safariLevel: ko.observable(1),
+    magicBallBonus: ko.observable(10),
+} -->
+<h3>Safari Catch Rate</h3>
+<div class="table-responsive">
+    <table class="table table-hover table-striped table-bordered">
         <tbody>
             <tr>
-                <td>HP per Pokémon</td>
-                <td data-bind="text: $data.enemyPokemon().health().toLocaleString('en-US')"></td>
+                <th>Safari Level</th>
+                <th>
+                    <input type="number" min="1" step="1" max="40" value="1" data-bind="textInput: safariLevel" />
+                </th>
             </tr>
             <tr>
-                <td>HP in Total</td>
-                <td data-bind="text: ($data.enemyPokemon().health() * 3).toLocaleString('en-US')"></td>
-            </tr>
-            <tr>
-                <td>Damage required (after types)</td>
-                <td data-bind="text: Math.ceil($data.enemyPokemon().health() * 3 / 30).toLocaleString('en-US')"></td>
-            </tr>
-            <tr>
-                <td>Battle Points</td>
-                <td data-bind="text: Math.round($data.stage() * Math.max($data.stage() / 100, 1)).toLocaleString()"></td>
-            </tr>
-            <tr>
-                <td>Pokédollars</td>
-                <td data-bind="text: ($data.stage() * 100 * Math.max($data.stage() / 100, 1)).toLocaleString()"></td>
-            </tr>
-            <tr>
-                <td>Egg Steps per Pokémon</td>
-                <td data-bind="text: +Math.sqrt($data.stage()).toFixed(2)"></td>
-            </tr>
-            <tr>
-                <td>Gems per Pokémon</td>
-                <td data-bind="text: Math.ceil($data.stage() / 80).toLocaleString()"></td>
+                <th>Magic Ball</th>
+                <th>
+                    <select class="form-select form-select-sm" data-bind="
+                            options: [{ bonus: 0 }, ...magicBallBonusList],
+                            optionsText: (item)=>
+                        {
+                        return item.bonus == 0 ? 'Not Equipped' : `Level ${item.level}`;
+                        },
+                        optionsValue: 'bonus',
+                        value: magicBallBonus" autocomplete="off">
+                    </select>
+                </th>
             </tr>
         </tbody>
     </table>
+    </div>
+<div class="accordion">
+    <div class="accordion-item">
+        <h2 class="accordion-header">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-6haol" aria-expanded="false">
+                Catch Rate Table
+            </button>
+        </h2>
+        <div id="collapse-6haol" class="accordion-collapse collapse" style="">
+            <div class="accordion-body">
+                <!-- ko with: [{ value: 0, label: 'Safari Zone' }, { value: 1, label: 'National Park' }, { value: 3, label: 'Great Marsh' }, { value: 5, label: 'Friend Safari' }, { value: 6, label: 'Hoppy Town Fishing Pond' }] -->
+                <ul class="nav nav-tabs" role="tablist" data-bind="foreach: $data">
+                    <li class="nav-item" role="presentation">
+                        <button class="nav-link" data-bs-toggle="tab" type="button" role="tab"
+                                data-bind="text: $data.label, attr: { id: `tab-${$index()}`, 'data-bs-target': `#tab-${$index()}-pane` }, css: { active: $index() == 0 }"></button>
+                    </li>
+                </ul>
+                <div class="tab-content mb-2" data-bind="foreach: $data">
+                    <div class="tab-pane fade pt-2" role="tabpanel" data-bind="attr: { id: `tab-${$index()}-pane` }, css: { show: $index() == 0, active: $index() == 0 }">
+                        <h4 data-bind="text: `${$data.label}`"></h4>
+                        <table class="table table-hover table-striped table-bordered " data-paging="false" data-filter="false">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Pokémon</th>
+                                    <th>Base Catch Rate</th>
+                                    <th>Base Catch Chance</th>
+                                    <th>Best Catch Chance</th>
+                                </tr>
+                            </thead>
+                            <tbody data-bind="foreach: pokemonList.filter((p) =>
+                                ($data.value == 5 ? (PokemonLocations.isObtainableAndNotEvable(p.name)
+                                && PokemonHelper.calcNativeRegion(p.name) <= GameConstants.MAX_AVAILABLE_REGION) || SafariPokemonList.list[GameConstants.Region.kalos]().find(x =>x.name == p.name) : PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]!== undefined && (Object.keys(PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]) == $data.value || Object.keys(PokemonLocations.getPokemonLocations(p.name)[PokemonLocationType.Safari]).includes(String($data.value))  )  ) ) ">
+                                <tr class="align-middle">
+                                    <td data-bind="text: `#${Math.floor($data.id).toString().padStart(3, '0')}`, attr: { 'data-sort': $data.id }"></td>
+                                    <td>
+                                        <a class="text-decoration-none" href="#!" data-bind="text: $data.name, attr: { href: `#!Pokemon/${$data.name}` }"></a>
+                                    </td>
+                                    <td data-bind="text: $data.catchRate"></td>
+                                    <td data-bind="text: ($data.catchRate / 6 ).toFixed(2)  + '%'"></td>
+                                    <td data-bind="text: (() =>
+                                        {
+                                        const level = safariLevel() < 0 ? 1 : safariLevel() > 40 ? 40 : safariLevel();
+                                        const multiplier = ((level - 1) /  50);
+                                        const baseEscape = 30;
+                                        const basecatchRate = ($data.catchRate / 6 ) + magicBallBonus() + (multiplier * 10);
+
+                                        function eatingCatch (catchChance) { return (catchChance / (2 - multiplier)) > 100 ? 100 : (catchChance / (2 - multiplier)); }
+                                        function angryCatch (catchChance)  { return (catchChance * (2 + multiplier)) > 100 ? 100 :  (catchChance * (2 + multiplier)); }
+                                        function nanabCatch (catchChance)  { return (catchChance * (1.5 + multiplier)) > 100 ? 100 : (catchChance * (1.5 + multiplier)); }
+                                        function eatingEscape (escapeChance) { return (escapeChance / (4 + multiplier));}
+                                        function angryEscape (escapeChance) { return (escapeChance * (2 - multiplier));}
+                                        function razzEscape (escapeChance) { return (escapeChance / (1.5 + multiplier));}
+
+
+                                        const eatingEscapeChance = 1-(eatingEscape(baseEscape) / 100);
+                                        const angryEscapeChance = 1-(angryEscape(baseEscape) / 100);
+                                        const razzEatingEscapeChance = 1-(razzEscape(eatingEscape(baseEscape)) / 100);
+                                        const razzAngryEscapeChance = 1-(razzEscape(angryEscape(baseEscape)) / 100);
+
+
+                                        const catchMethods = {
+                                        Bait : eatingEscapeChance  * eatingCatch(basecatchRate),
+                                        Rock : angryEscapeChance * angryCatch(basecatchRate),
+                                        BaitRock : eatingEscapeChance * angryEscapeChance * angryCatch(basecatchRate),
+                                        Nanab : eatingEscapeChance  * nanabCatch(eatingCatch(basecatchRate)),
+                                        NanabRock : eatingEscapeChance  * angryEscapeChance *  nanabCatch(angryCatch(basecatchRate)),
+                                        Razz : razzEatingEscapeChance  *  eatingCatch(basecatchRate),
+                                        RazzRock : razzEatingEscapeChance * razzAngryEscapeChance * angryCatch(basecatchRate)
+                                        };
+
+                                        const largestVariable = Object.keys(catchMethods).reduce((x, y) => catchMethods[x] > catchMethods[y] ? x : y);
+                                        const methodText = largestVariable.replace('Rock', ' Rock');
+
+                                        return (`${methodText} with ${catchMethods[largestVariable].toFixed(2)}% chance on the first ball`).toLocaleString();
+                                        })()">
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <!-- /ko -->
+            </div>
+           </div>
+      </div>
 </div>
+
+            <!-- /ko -->
+            <!-- /ko -->

--- a/pages/Safari/overview.html
+++ b/pages/Safari/overview.html
@@ -1,7 +1,5 @@
 <!-- ko let: {
     magicBallBonusList: App.game.oakItems.itemList[OakItemType.Magic_Ball].bonusList.map((b, i) => ({ level: i, bonus: b })),
-} -->
-<!-- ko let: {
     safariLevel: ko.observable(1),
     magicBallBonus: ko.observable(10),
 } -->
@@ -31,7 +29,7 @@
             </tr>
         </tbody>
     </table>
-    </div>
+</div>
 <div class="accordion">
     <div class="accordion-item">
         <h2 class="accordion-header">
@@ -115,9 +113,7 @@
                 </div>
                 <!-- /ko -->
             </div>
-           </div>
-      </div>
+        </div>
+    </div>
 </div>
-
-            <!-- /ko -->
-            <!-- /ko -->
+<!-- /ko -->


### PR DESCRIPTION
Added new safari catch table, default collapsed at the bottom, includes tabbed safari catch zones and reactive element based on safari level and magic ball use.

<img width="1447" height="614" alt="image" src="https://github.com/user-attachments/assets/d11acf0f-750b-4c25-b43a-916581819305" />
